### PR TITLE
Add mobile sidebar with HTML5 popover API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 
 ## Tech Stack
 
+- **Package Manager**: pnpm (use `pnpm install`, not npm)
 - **Framework**: React Router 7 (SPA mode, `ssr: false`)
 - **Styling**: Tailwind CSS 4
 - **State**: Zustand (with localStorage persistence for settings)

--- a/app/app.css
+++ b/app/app.css
@@ -88,3 +88,47 @@ body {
 .animate-pulse-subtle {
   animation: pulse-subtle 2s ease-in-out infinite;
 }
+
+/* Mobile sidebar popover styles */
+.sidebar-popover {
+  position: fixed;
+  inset: 0 auto 0 0;
+  transform: translateX(0);
+  opacity: 1;
+  transition:
+    transform 0.3s cubic-bezier(0.32, 0.72, 0, 1),
+    opacity 0.3s ease,
+    overlay 0.3s allow-discrete,
+    display 0.3s allow-discrete;
+}
+
+.sidebar-popover::backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 1;
+  transition:
+    opacity 0.3s ease,
+    overlay 0.3s allow-discrete,
+    display 0.3s allow-discrete;
+}
+
+/* Closed state - slide out to left */
+.sidebar-popover:not(:popover-open) {
+  transform: translateX(-100%);
+  opacity: 0;
+}
+
+.sidebar-popover:not(:popover-open)::backdrop {
+  opacity: 0;
+}
+
+/* Starting style for entry animation */
+@starting-style {
+  .sidebar-popover:popover-open {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+
+  .sidebar-popover:popover-open::backdrop {
+    opacity: 0;
+  }
+}

--- a/app/app.css
+++ b/app/app.css
@@ -132,3 +132,49 @@ body {
     opacity: 0;
   }
 }
+
+/* Settings modal popover styles */
+.settings-popover {
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  transform: scale(1);
+  opacity: 1;
+  transition:
+    transform 0.2s cubic-bezier(0.32, 0.72, 0, 1),
+    opacity 0.2s ease,
+    overlay 0.2s allow-discrete,
+    display 0.2s allow-discrete;
+}
+
+.settings-popover::backdrop {
+  background-color: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  opacity: 1;
+  transition:
+    opacity 0.2s ease,
+    overlay 0.2s allow-discrete,
+    display 0.2s allow-discrete;
+}
+
+/* Closed state */
+.settings-popover:not(:popover-open) {
+  transform: scale(0.95);
+  opacity: 0;
+}
+
+.settings-popover:not(:popover-open)::backdrop {
+  opacity: 0;
+}
+
+/* Starting style for entry animation */
+@starting-style {
+  .settings-popover:popover-open {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+
+  .settings-popover:popover-open::backdrop {
+    opacity: 0;
+  }
+}

--- a/app/app.css
+++ b/app/app.css
@@ -135,11 +135,11 @@ body {
 
 /* Settings modal popover styles */
 .settings-popover {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  translate: -50% -50%;
-  margin: 0;
+  /* Popover is in top layer - use inset + margin for centering */
+  inset: 0;
+  margin: auto;
+  width: fit-content;
+  height: fit-content;
   transform: scale(1);
   opacity: 1;
   transition:

--- a/app/app.css
+++ b/app/app.css
@@ -136,8 +136,10 @@ body {
 /* Settings modal popover styles */
 .settings-popover {
   position: fixed;
-  inset: 0;
-  margin: auto;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  margin: 0;
   transform: scale(1);
   opacity: 1;
   transition:

--- a/app/app.css
+++ b/app/app.css
@@ -137,9 +137,6 @@ body {
 .settings-popover {
   /* Popover is in top layer - use inset + margin for centering */
   inset: 0;
-  margin: auto;
-  width: fit-content;
-  height: fit-content;
   transform: scale(1);
   opacity: 1;
   transition:

--- a/app/components/settings/AddCustomModelButton.tsx
+++ b/app/components/settings/AddCustomModelButton.tsx
@@ -1,0 +1,101 @@
+import { Plus, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { fetchModelInfo } from "~/lib/replicateSchema";
+import { useSettingsStore } from "~/stores/settingsStore";
+
+export default function AddCustomModelButton({ disabled, apiKey }: { disabled?: boolean; apiKey: string | null }) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [modelId, setModelId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addCustomModel = useSettingsStore((s) => s.addCustomModel);
+  const models = useSettingsStore((s) => s.models);
+
+  const handleAdd = async () => {
+    if (!modelId.trim()) return;
+
+    // Validate format (owner/model)
+    if (!modelId.includes("/")) {
+      setError("Format: owner/model-name");
+      return;
+    }
+
+    // Check if already exists
+    const fullId = `replicate/${modelId}`;
+    if (models.some((m) => m.id === fullId)) {
+      setError("Model already added");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { name, capabilities } = await fetchModelInfo(modelId, apiKey!);
+      addCustomModel(modelId, name, capabilities);
+      setModelId("");
+      setIsAdding(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch model");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isAdding) {
+    return (
+      <button
+        onClick={() => setIsAdding(true)}
+        disabled={disabled}
+        className={`flex items-center gap-2 w-full p-2.5 rounded-lg border border-dashed border-zinc-700 text-zinc-400 transition-colors ${
+          disabled ? "opacity-50 cursor-not-allowed" : "hover:text-zinc-300 hover:border-zinc-600"
+        }`}
+      >
+        <Plus className="w-4 h-4" />
+        <span className="text-sm">Add custom Replicate model</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-2 p-3 rounded-lg border border-zinc-700 bg-zinc-800/50">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={modelId}
+          onChange={(e) => {
+            setModelId(e.target.value);
+            setError(null);
+          }}
+          placeholder="owner/model-name"
+          className="flex-1 py-2 px-3 bg-zinc-900 border border-zinc-700 rounded-lg text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-purple-500 focus:ring-1 focus:ring-purple-500"
+          onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+          autoFocus
+        />
+        <button
+          onClick={handleAdd}
+          disabled={loading || !modelId.trim()}
+          className="px-3 py-2 bg-purple-600 hover:bg-purple-500 disabled:bg-zinc-700 disabled:text-zinc-500 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-1.5"
+        >
+          {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+          Add
+        </button>
+        <button
+          onClick={() => {
+            setIsAdding(false);
+            setModelId("");
+            setError(null);
+          }}
+          className="px-3 py-2 bg-zinc-700 hover:bg-zinc-600 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+      <p className="text-xs text-zinc-500">
+        Enter a Replicate model ID like "stability-ai/sdxl" or "black-forest-labs/flux-schnell"
+      </p>
+    </div>
+  );
+}

--- a/app/components/settings/ModelToggle.tsx
+++ b/app/components/settings/ModelToggle.tsx
@@ -1,0 +1,91 @@
+import { Maximize, RectangleHorizontal, Trash2, Image, Box } from "lucide-react";
+import { useSettingsStore } from "~/stores/settingsStore";
+import SVG from "react-inlinesvg";
+import type { StoredModel } from "~/types";
+
+
+function CapabilityBadge({ icon: Icon, label, enabled }: { icon: React.ElementType; label: string; enabled: boolean }) {
+  if (!enabled) return null;
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-zinc-700/50 text-zinc-400"
+      title={label}
+    >
+      <Icon className="w-2.5 h-2.5" />
+    </span>
+  );
+}
+
+export default function ModelToggleItem({
+  model,
+  hasApiKey,
+}: {
+  model: StoredModel;
+  hasApiKey: boolean;
+}) {
+  const setModelEnabled = useSettingsStore((s) => s.setModelEnabled);
+  const removeCustomModel = useSettingsStore((s) => s.removeCustomModel);
+
+  const { capabilities } = model;
+
+  return (
+    <div
+      className={`flex items-center gap-3 p-2.5 rounded-lg bg-zinc-800/50 border border-zinc-700/50 ${
+        !hasApiKey ? "opacity-50" : ""
+      }`}
+    >
+      <div className="w-7 h-7 rounded-lg bg-zinc-700 flex items-center justify-center text-zinc-400 shrink-0">
+        {model.icon ? (
+          <SVG src={model.icon} className="w-5 h-5" />
+        ) : (
+          <Box className="w-4 h-4" />
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-zinc-100 truncate">{model.name}</p>
+        <div className="flex items-center gap-1.5 mt-0.5">
+          <span className="text-xs text-zinc-500 capitalize">{model.provider}</span>
+          <div className="flex items-center gap-1">
+            <CapabilityBadge
+              icon={RectangleHorizontal}
+              label="Aspect ratio"
+              enabled={capabilities.supportsAspectRatios}
+            />
+            <CapabilityBadge
+              icon={Maximize}
+              label="Resolution"
+              enabled={capabilities.supportsResolution}
+            />
+            <CapabilityBadge
+              icon={Image}
+              label={`Reference images (max ${capabilities.maxReferenceImages})`}
+              enabled={capabilities.supportsReferenceImages}
+            />
+          </div>
+        </div>
+      </div>
+
+      {model.isCustom && (
+        <button
+          onClick={() => removeCustomModel(model.id)}
+          className="p-1.5 text-zinc-500 hover:text-red-400 transition-colors shrink-0"
+          title="Remove model"
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      )}
+
+      <label className="relative inline-flex items-center cursor-pointer shrink-0">
+        <input
+          type="checkbox"
+          checked={model.enabled}
+          onChange={(e) => setModelEnabled(model.id, e.target.checked)}
+          className="sr-only peer"
+          disabled={!hasApiKey}
+        />
+        <div className="w-9 h-5 bg-zinc-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-0.5 after:bg-zinc-400 after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-purple-600 peer-checked:after:bg-white"></div>
+      </label>
+    </div>
+  );
+}

--- a/app/components/settings/SettingsModal.tsx
+++ b/app/components/settings/SettingsModal.tsx
@@ -85,7 +85,7 @@ export function SettingsModal() {
       ref={popoverRef}
       id={SETTINGS_POPOVER_ID}
       popover="manual"
-      className="settings-popover bg-zinc-900 border border-zinc-800 rounded-xl w-full max-w-lg shadow-2xl max-h-[85vh] flex flex-col"
+      className="settings-popover bg-zinc-900 border border-zinc-800 rounded-xl w-[calc(100%-2rem)] max-w-lg shadow-2xl max-h-[calc(100vh-2rem)] flex flex-col"
     >
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-zinc-800 shrink-0">
@@ -163,15 +163,6 @@ export function SettingsModal() {
         </div>
       </div>
 
-      {/* Footer */}
-      <div className="p-4 border-t border-zinc-800 shrink-0">
-        <button
-          onClick={handleClose}
-          className="w-full py-2 px-4 bg-purple-600 hover:bg-purple-500 text-white font-medium rounded-lg transition-colors"
-        >
-          Done
-        </button>
-      </div>
     </div>
   );
 }

--- a/app/components/settings/SettingsModal.tsx
+++ b/app/components/settings/SettingsModal.tsx
@@ -62,7 +62,7 @@ export function SettingsModal() {
     <div
       id={SETTINGS_POPOVER_ID}
       popover="auto"
-      className="settings-popover bg-zinc-900 border border-zinc-800 rounded-xl w-[90vw] max-w-lg shadow-2xl max-h-[90vh] flex flex-col"
+      className="settings-popover m-auto bg-zinc-900 border border-zinc-800 rounded-xl w-[calc(100vw-1rem)] max-w-lg shadow-2xl max-h-[90vh] flex flex-col"
     >
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-zinc-800 shrink-0">

--- a/app/components/settings/SettingsModal.tsx
+++ b/app/components/settings/SettingsModal.tsx
@@ -85,7 +85,7 @@ export function SettingsModal() {
       ref={popoverRef}
       id={SETTINGS_POPOVER_ID}
       popover="manual"
-      className="settings-popover bg-zinc-900 border border-zinc-800 rounded-xl w-[calc(100%-2rem)] max-w-lg shadow-2xl max-h-[calc(100vh-2rem)] flex flex-col"
+      className="settings-popover bg-zinc-900 border border-zinc-800 rounded-xl w-[90vw] max-w-lg shadow-2xl max-h-[90vh] flex flex-col"
     >
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-zinc-800 shrink-0">

--- a/app/components/settings/SettingsModal.tsx
+++ b/app/components/settings/SettingsModal.tsx
@@ -1,8 +1,10 @@
-import { X, Key, Eye, EyeOff, Check, Plus, Trash2, Sparkles, Box, ChevronDown, ChevronUp, Loader2, RectangleHorizontal, Maximize, Image } from "lucide-react";
-import { useState, useEffect, useRef } from "react";
+import { X, Key, Eye, EyeOff, Check, Sparkles, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+import { useState, useEffect } from "react";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { fetchModelInfo } from "~/lib/replicateSchema";
-import type { Provider, StoredModel } from "~/types";
+import type { Provider } from "~/types";
+import ModelToggleItem from "./ModelToggle";
+import AddCustomModelButton from "./AddCustomModelButton";
 
 export const SETTINGS_POPOVER_ID = "settings-popover";
 
@@ -20,35 +22,15 @@ const providers: { id: Provider; name: string; description: string }[] = [
 ];
 
 export function SettingsModal() {
-  const closeSettingsModal = useSettingsStore((s) => s.closeSettingsModal);
   const apiKeys = useSettingsStore((s) => s.apiKeys);
   const models = useSettingsStore((s) => s.models);
   const setApiKey = useSettingsStore((s) => s.setApiKey);
   const updateModelCapabilities = useSettingsStore((s) => s.updateModelCapabilities);
 
-  const popoverRef = useRef<HTMLDivElement>(null);
   const [apiKeysExpanded, setApiKeysExpanded] = useState(
     !apiKeys.google && !apiKeys.replicate
   );
   const [fetchingSchemas, setFetchingSchemas] = useState(false);
-
-  // Show popover on mount and handle toggle event for closing
-  useEffect(() => {
-    const popover = popoverRef.current;
-    if (!popover) return;
-
-    popover.showPopover();
-
-    const handleToggle = (e: Event) => {
-      const toggleEvent = e as ToggleEvent;
-      if (toggleEvent.newState === "closed") {
-        closeSettingsModal();
-      }
-    };
-
-    popover.addEventListener("toggle", handleToggle);
-    return () => popover.removeEventListener("toggle", handleToggle);
-  }, [closeSettingsModal]);
 
   // Fetch schemas for Replicate models that haven't been fetched yet
   useEffect(() => {
@@ -76,22 +58,17 @@ export function SettingsModal() {
     });
   }, [apiKeys.replicate, models, updateModelCapabilities]);
 
-  const handleClose = () => {
-    popoverRef.current?.hidePopover();
-  };
-
   return (
     <div
-      ref={popoverRef}
       id={SETTINGS_POPOVER_ID}
-      popover="manual"
+      popover="auto"
       className="settings-popover bg-zinc-900 border border-zinc-800 rounded-xl w-[90vw] max-w-lg shadow-2xl max-h-[90vh] flex flex-col"
     >
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-zinc-800 shrink-0">
         <h2 className="text-lg font-semibold">Settings</h2>
         <button
-          onClick={handleClose}
+          popoverTarget={SETTINGS_POPOVER_ID}
           className="p-1.5 rounded-lg hover:bg-zinc-800 transition-colors"
         >
           <X className="w-5 h-5 text-zinc-400" />
@@ -208,191 +185,6 @@ function ApiKeyInput({
           {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
         </button>
       </div>
-    </div>
-  );
-}
-
-function CapabilityBadge({ icon: Icon, label, enabled }: { icon: React.ElementType; label: string; enabled: boolean }) {
-  if (!enabled) return null;
-  return (
-    <span
-      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-zinc-700/50 text-zinc-400"
-      title={label}
-    >
-      <Icon className="w-2.5 h-2.5" />
-    </span>
-  );
-}
-
-function ModelToggleItem({
-  model,
-  hasApiKey,
-}: {
-  model: StoredModel;
-  hasApiKey: boolean;
-}) {
-  const setModelEnabled = useSettingsStore((s) => s.setModelEnabled);
-  const removeCustomModel = useSettingsStore((s) => s.removeCustomModel);
-
-  const providerIcon = model.provider === "google" ? (
-    <Sparkles className="w-4 h-4" />
-  ) : (
-    <Box className="w-4 h-4" />
-  );
-
-  const { capabilities } = model;
-
-  return (
-    <div
-      className={`flex items-center gap-3 p-2.5 rounded-lg bg-zinc-800/50 border border-zinc-700/50 ${
-        !hasApiKey ? "opacity-50" : ""
-      }`}
-    >
-      <div className="w-7 h-7 rounded-lg bg-zinc-700 flex items-center justify-center text-zinc-400 shrink-0">
-        {providerIcon}
-      </div>
-
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-zinc-100 truncate">{model.name}</p>
-        <div className="flex items-center gap-1.5 mt-0.5">
-          <span className="text-xs text-zinc-500 capitalize">{model.provider}</span>
-          <div className="flex items-center gap-1">
-            <CapabilityBadge
-              icon={RectangleHorizontal}
-              label="Aspect ratio"
-              enabled={capabilities.supportsAspectRatios}
-            />
-            <CapabilityBadge
-              icon={Maximize}
-              label="Resolution"
-              enabled={capabilities.supportsResolution}
-            />
-            <CapabilityBadge
-              icon={Image}
-              label={`Reference images (max ${capabilities.maxReferenceImages})`}
-              enabled={capabilities.supportsReferenceImages}
-            />
-          </div>
-        </div>
-      </div>
-
-      {model.isCustom && (
-        <button
-          onClick={() => removeCustomModel(model.id)}
-          className="p-1.5 text-zinc-500 hover:text-red-400 transition-colors shrink-0"
-          title="Remove model"
-        >
-          <Trash2 className="w-4 h-4" />
-        </button>
-      )}
-
-      <label className="relative inline-flex items-center cursor-pointer shrink-0">
-        <input
-          type="checkbox"
-          checked={model.enabled}
-          onChange={(e) => setModelEnabled(model.id, e.target.checked)}
-          className="sr-only peer"
-          disabled={!hasApiKey}
-        />
-        <div className="w-9 h-5 bg-zinc-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-0.5 after:bg-zinc-400 after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-purple-600 peer-checked:after:bg-white"></div>
-      </label>
-    </div>
-  );
-}
-
-function AddCustomModelButton({ disabled, apiKey }: { disabled?: boolean; apiKey: string | null }) {
-  const [isAdding, setIsAdding] = useState(false);
-  const [modelId, setModelId] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const addCustomModel = useSettingsStore((s) => s.addCustomModel);
-  const models = useSettingsStore((s) => s.models);
-
-  const handleAdd = async () => {
-    if (!modelId.trim()) return;
-
-    // Validate format (owner/model)
-    if (!modelId.includes("/")) {
-      setError("Format: owner/model-name");
-      return;
-    }
-
-    // Check if already exists
-    const fullId = `replicate/${modelId}`;
-    if (models.some((m) => m.id === fullId)) {
-      setError("Model already added");
-      return;
-    }
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const { name, capabilities } = await fetchModelInfo(modelId, apiKey!);
-      addCustomModel(modelId, name, capabilities);
-      setModelId("");
-      setIsAdding(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to fetch model");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  if (!isAdding) {
-    return (
-      <button
-        onClick={() => setIsAdding(true)}
-        disabled={disabled}
-        className={`flex items-center gap-2 w-full p-2.5 rounded-lg border border-dashed border-zinc-700 text-zinc-400 transition-colors ${
-          disabled ? "opacity-50 cursor-not-allowed" : "hover:text-zinc-300 hover:border-zinc-600"
-        }`}
-      >
-        <Plus className="w-4 h-4" />
-        <span className="text-sm">Add custom Replicate model</span>
-      </button>
-    );
-  }
-
-  return (
-    <div className="space-y-2 p-3 rounded-lg border border-zinc-700 bg-zinc-800/50">
-      <div className="flex gap-2">
-        <input
-          type="text"
-          value={modelId}
-          onChange={(e) => {
-            setModelId(e.target.value);
-            setError(null);
-          }}
-          placeholder="owner/model-name"
-          className="flex-1 py-2 px-3 bg-zinc-900 border border-zinc-700 rounded-lg text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-purple-500 focus:ring-1 focus:ring-purple-500"
-          onKeyDown={(e) => e.key === "Enter" && handleAdd()}
-          autoFocus
-        />
-        <button
-          onClick={handleAdd}
-          disabled={loading || !modelId.trim()}
-          className="px-3 py-2 bg-purple-600 hover:bg-purple-500 disabled:bg-zinc-700 disabled:text-zinc-500 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-1.5"
-        >
-          {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-          Add
-        </button>
-        <button
-          onClick={() => {
-            setIsAdding(false);
-            setModelId("");
-            setError(null);
-          }}
-          className="px-3 py-2 bg-zinc-700 hover:bg-zinc-600 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
-        >
-          Cancel
-        </button>
-      </div>
-      {error && <p className="text-xs text-red-400">{error}</p>}
-      <p className="text-xs text-zinc-500">
-        Enter a Replicate model ID like "stability-ai/sdxl" or "black-forest-labs/flux-schnell"
-      </p>
     </div>
   );
 }

--- a/app/components/sidebar/GenerateButton.tsx
+++ b/app/components/sidebar/GenerateButton.tsx
@@ -3,15 +3,14 @@ import { useGalleryStore } from "~/stores/galleryStore";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { useImageGeneration } from "~/hooks/useImageGeneration";
 import { getModel } from "~/lib/models";
+import { SETTINGS_POPOVER_ID } from "../settings/SettingsModal";
 
 export function GenerateButton() {
   const prompt = useGalleryStore((s) => s.currentPrompt);
   const modelSelections = useGalleryStore((s) => s.currentModelSelections);
-  const aspectRatio = useGalleryStore((s) => s.currentAspectRatio);
   const isGenerating = useGalleryStore((s) => s.isGenerating);
   const models = useSettingsStore((s) => s.models);
   const apiKeys = useSettingsStore((s) => s.apiKeys);
-  const openSettingsModal = useSettingsStore((s) => s.openSettingsModal);
 
   const { generate } = useImageGeneration();
 
@@ -30,7 +29,8 @@ export function GenerateButton() {
 
   const handleGenerate = () => {
     if (missingKeys) {
-      openSettingsModal();
+      const settingsPopover = document.getElementById(SETTINGS_POPOVER_ID);
+      settingsPopover?.showPopover();
       return;
     }
     if (canGenerate) {

--- a/app/components/sidebar/MobileHeader.tsx
+++ b/app/components/sidebar/MobileHeader.tsx
@@ -1,0 +1,25 @@
+import { Droplet, Menu } from "lucide-react";
+import { SIDEBAR_POPOVER_ID } from "./Sidebar";
+
+export function MobileHeader() {
+  return (
+    <header className="md:hidden flex items-center justify-between px-4 py-3 border-b border-zinc-800 bg-zinc-900">
+      <div className="flex items-center gap-3">
+        <div className="w-8 h-8 rounded-lg bg-zinc-800 flex items-center justify-center">
+          <Droplet className="w-4 h-4 text-purple-400" />
+        </div>
+        <div>
+          <h1 className="font-semibold text-sm">Paintball</h1>
+          <p className="text-xs text-zinc-500">AI Image Generation</p>
+        </div>
+      </div>
+      <button
+        popoverTarget={SIDEBAR_POPOVER_ID}
+        className="p-2 rounded-lg hover:bg-zinc-800 transition-colors"
+        aria-label="Open menu"
+      >
+        <Menu className="w-5 h-5 text-zinc-400" />
+      </button>
+    </header>
+  );
+}

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -5,13 +5,11 @@ import { AspectRatioSection } from "./AspectRatioSection";
 import { ResolutionSection } from "./ResolutionSection";
 import { ReferenceImages } from "./ReferenceImages";
 import { GenerateButton } from "./GenerateButton";
-import { useSettingsStore } from "~/stores/settingsStore";
+import { SETTINGS_POPOVER_ID } from "../settings/SettingsModal";
 
 export const SIDEBAR_POPOVER_ID = "sidebar-popover";
 
 function SidebarContent({ onClose }: { onClose?: () => void }) {
-  const openSettingsModal = useSettingsStore((s) => s.openSettingsModal);
-
   return (
     <>
       {/* Header */}
@@ -27,7 +25,7 @@ function SidebarContent({ onClose }: { onClose?: () => void }) {
         </div>
         <div className="flex items-center gap-1">
           <button
-            onClick={openSettingsModal}
+            popoverTarget={SETTINGS_POPOVER_ID}
             className="p-2 rounded-lg hover:bg-zinc-800 transition-colors"
             aria-label="Settings"
           >

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Droplet, Settings } from "lucide-react";
+import { Droplet, Settings, X } from "lucide-react";
 import { PromptInput } from "./PromptInput";
 import { ModelList } from "./ModelList";
 import { AspectRatioSection } from "./AspectRatioSection";
@@ -7,11 +7,13 @@ import { ReferenceImages } from "./ReferenceImages";
 import { GenerateButton } from "./GenerateButton";
 import { useSettingsStore } from "~/stores/settingsStore";
 
-export function Sidebar() {
+export const SIDEBAR_POPOVER_ID = "sidebar-popover";
+
+function SidebarContent({ onClose }: { onClose?: () => void }) {
   const openSettingsModal = useSettingsStore((s) => s.openSettingsModal);
 
   return (
-    <aside className="w-80 shrink-0 border-r border-zinc-800 bg-zinc-900 flex flex-col h-full">
+    <>
       {/* Header */}
       <div className="px-6 py-4 flex items-center justify-between border-b border-zinc-800 h-18">
         <div className="flex items-center gap-3">
@@ -23,13 +25,24 @@ export function Sidebar() {
             <p className="text-xs text-zinc-500">AI Image Generation</p>
           </div>
         </div>
-        <button
-          onClick={openSettingsModal}
-          className="p-2 rounded-lg hover:bg-zinc-800 transition-colors"
-          aria-label="Settings"
-        >
-          <Settings className="w-4 h-4 text-zinc-400" />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={openSettingsModal}
+            className="p-2 rounded-lg hover:bg-zinc-800 transition-colors"
+            aria-label="Settings"
+          >
+            <Settings className="w-4 h-4 text-zinc-400" />
+          </button>
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="p-2 rounded-lg hover:bg-zinc-800 transition-colors md:hidden"
+              aria-label="Close sidebar"
+            >
+              <X className="w-4 h-4 text-zinc-400" />
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Scrollable Content */}
@@ -45,6 +58,31 @@ export function Sidebar() {
       <div className="p-4 border-t border-zinc-800">
         <GenerateButton />
       </div>
+    </>
+  );
+}
+
+export function Sidebar() {
+  return (
+    <aside className="hidden md:flex w-80 shrink-0 border-r border-zinc-800 bg-zinc-900 flex-col h-full">
+      <SidebarContent />
+    </aside>
+  );
+}
+
+export function MobileSidebar() {
+  const handleClose = () => {
+    const popover = document.getElementById(SIDEBAR_POPOVER_ID);
+    popover?.hidePopover();
+  };
+
+  return (
+    <aside
+      id={SIDEBAR_POPOVER_ID}
+      popover="auto"
+      className="sidebar-popover m-0 p-0 w-80 max-w-[85vw] h-full max-h-full border-0 border-r border-zinc-800 bg-zinc-900 flex flex-col"
+    >
+      <SidebarContent onClose={handleClose} />
     </aside>
   );
 }

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -33,7 +33,7 @@ export default function Home() {
       <MobileSidebar />
       <Sidebar />
       <Gallery />
-      {settingsModalOpen && <SettingsModal />}
+      <SettingsModal />
       {isLightboxOpen && <Lightbox />}
     </div>
   );

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/home";
 import { useEffect } from "react";
-import { Sidebar } from "~/components/sidebar/Sidebar";
+import { Sidebar, MobileSidebar } from "~/components/sidebar/Sidebar";
+import { MobileHeader } from "~/components/sidebar/MobileHeader";
 import { Gallery } from "~/components/gallery/Gallery";
 import { SettingsModal } from "~/components/settings/SettingsModal";
 import { Lightbox } from "~/components/lightbox/Lightbox";
@@ -27,7 +28,9 @@ export default function Home() {
   }, [hasLoaded, loadImages]);
 
   return (
-    <div className="flex h-screen">
+    <div className="flex flex-col md:flex-row h-screen">
+      <MobileHeader />
+      <MobileSidebar />
       <Sidebar />
       <Gallery />
       {settingsModalOpen && <SettingsModal />}

--- a/app/stores/settingsStore.ts
+++ b/app/stores/settingsStore.ts
@@ -118,10 +118,6 @@ interface SettingsState {
   addCustomModel: (id: string, name: string, capabilities: ModelCapabilities) => void;
   removeCustomModel: (id: string) => void;
   updateModelCapabilities: (id: string, capabilities: ModelCapabilities, schemaFetched?: boolean) => void;
-
-  // Modal actions
-  openSettingsModal: () => void;
-  closeSettingsModal: () => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -178,9 +174,6 @@ export const useSettingsStore = create<SettingsState>()(
             m.id === id ? { ...m, capabilities, ...(schemaFetched !== undefined && { schemaFetched }) } : m
           ),
         })),
-
-      openSettingsModal: () => set({ settingsModalOpen: true }),
-      closeSettingsModal: () => set({ settingsModalOpen: false }),
     }),
     {
       name: 'studio-settings',


### PR DESCRIPTION
Implement responsive mobile UI for the sidebar using native HTML5
popover tags with animated slide-in/out transitions. Features:
- MobileSidebar component using popover="auto" attribute
- MobileHeader with hamburger menu button (popovertarget)
- Close button inside sidebar for easy dismissal
- Smooth CSS animations using @starting-style for entry/exit
- Backdrop overlay that fades in/out
- Desktop layout unchanged (hidden on mobile via md: breakpoint)