### PR TITLE
Add image diff viewer with side-by-side comparison

### DIFF
--- a/app/components/editor/DiffViewer.tsx
+++ b/app/components/editor/DiffViewer.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import { useDiffStore } from "~/stores/diffStore";
+
+export function DiffViewer() {
+  const isOpen = useDiffStore((s) => s.isOpen);
+  const target = useDiffStore((s) => s.target);
+  const closeDiff = useDiffStore((s) => s.closeDiff);
+
+  if (!isOpen || !target) return null;
+  return <DiffViewerInner target={target} onClose={closeDiff} />;
+}
+
+function DiffViewerInner({
+  target,
+  onClose,
+}: {
+  target: NonNullable<ReturnType<typeof useDiffStore.getState>["target"]>;
+  onClose: () => void;
+}) {
+  const { parentBlob, childBlob, parentLabel, childLabel } = target;
+
+  const [parentUrl, setParentUrl] = useState<string | null>(null);
+  const [childUrl, setChildUrl] = useState<string | null>(null);
+  const [aspectRatio, setAspectRatio] = useState<number | null>(null);
+  const [position, setPosition] = useState(50);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const pUrl = URL.createObjectURL(parentBlob);
+    const cUrl = URL.createObjectURL(childBlob);
+    setParentUrl(pUrl);
+    setChildUrl(cUrl);
+
+    const img = new Image();
+    img.onload = () => {
+      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+        setAspectRatio(img.naturalWidth / img.naturalHeight);
+      }
+    };
+    img.src = pUrl;
+
+    return () => {
+      URL.revokeObjectURL(pUrl);
+      URL.revokeObjectURL(cUrl);
+    };
+  }, [parentBlob, childBlob]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const updatePositionFromEvent = (clientX: number) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const next = ((clientX - rect.left) / rect.width) * 100;
+    setPosition(Math.max(0, Math.min(100, next)));
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    updatePositionFromEvent(e.clientX);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.buttons === 0) return;
+    updatePositionFromEvent(e.clientX);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/90 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Close button */}
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 z-20 rounded-lg bg-zinc-900/80 p-2 transition-colors hover:bg-zinc-800"
+      >
+        <X className="h-6 w-6 text-zinc-300" />
+      </button>
+
+      {/* Compare surface */}
+      <div
+        ref={containerRef}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        className="animate-fade-in relative z-10 max-h-[90vh] max-w-[90vw] cursor-ew-resize touch-none overflow-hidden rounded-xl bg-zinc-900 shadow-2xl select-none"
+        style={aspectRatio ? { aspectRatio, width: `min(90vw, calc(90vh * ${aspectRatio}))` } : undefined}
+      >
+        {parentUrl && childUrl && (
+          <>
+            <img
+              src={parentUrl}
+              alt={parentLabel ?? "Before"}
+              draggable={false}
+              className="absolute inset-0 h-full w-full object-contain"
+            />
+            <img
+              src={childUrl}
+              alt={childLabel ?? "After"}
+              draggable={false}
+              className="absolute inset-0 h-full w-full object-contain"
+              style={{ clipPath: `inset(0 ${100 - position}% 0 0)` }}
+            />
+
+            {/* Divider line */}
+            <div
+              className="pointer-events-none absolute top-0 bottom-0 w-0.5 bg-white/90 shadow-lg"
+              style={{ left: `${position}%`, transform: "translateX(-50%)" }}
+            />
+
+            {/* Drag handle */}
+            <div
+              className="pointer-events-none absolute top-1/2 flex h-9 w-9 items-center justify-center rounded-full border-2 border-white/90 bg-black/50 shadow-lg backdrop-blur-sm"
+              style={{ left: `${position}%`, transform: "translate(-50%, -50%)" }}
+            >
+              <svg
+                className="h-4 w-4 text-white"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="9 6 3 12 9 18" />
+                <polyline points="15 6 21 12 15 18" />
+              </svg>
+            </div>
+
+            {/* Labels */}
+            <div className="pointer-events-none absolute top-3 left-3 rounded bg-black/60 px-2 py-1 text-xs font-medium text-white/90 backdrop-blur-sm">
+              {parentLabel ?? "Before"}
+            </div>
+            <div className="pointer-events-none absolute top-3 right-3 rounded bg-black/60 px-2 py-1 text-xs font-medium text-white/90 backdrop-blur-sm">
+              {childLabel ?? "After"}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/editor/EditorView.tsx
+++ b/app/components/editor/EditorView.tsx
@@ -4,6 +4,7 @@ import { GalleryHeader } from "~/components/gallery/GalleryHeader";
 import { TurnList } from "./TurnList";
 import { EditorInputBar } from "./EditorInputBar";
 import { DropZone } from "./DropZone";
+import { DiffViewer } from "./DiffViewer";
 import { getSessionByGalleryItemId, getSessionById, saveReferenceImage } from "~/lib/db";
 import { hydrateStoredSession } from "~/lib/editorSession";
 
@@ -83,6 +84,8 @@ export function EditorView() {
         {hasSource ? <TurnList /> : <DropZone onFile={(file) => void handleSourceFile(file)} />}
         <EditorInputBar onSourceFile={(file) => void handleSourceFile(file)} />
       </div>
+
+      <DiffViewer />
     </main>
   );
 }

--- a/app/components/editor/Turn.tsx
+++ b/app/components/editor/Turn.tsx
@@ -1,8 +1,9 @@
-import { Check, Link2, Maximize2 } from "lucide-react";
+import { Check, Layers2, Link2, Maximize2, Square } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useGalleryStore } from "~/stores/galleryStore";
 import { useEditorStore } from "~/stores/editorStore";
 import { useLightboxStore } from "~/stores/lightboxStore";
+import { useDiffStore } from "~/stores/diffStore";
 import type { EditorTurn } from "~/types";
 import { SineWaveGrid } from "~/components/gallery/SineWaveGrid";
 import { useGalleryDerivedIndexes } from "~/hooks/useGalleryDerivedIndexes";
@@ -42,6 +43,19 @@ export function Turn({ turn, turnIndex, isFirst = false }: TurnProps) {
         return () => URL.revokeObjectURL(url);
       }
     }
+  }, [getItemById, turn.sourceItemId, turn.sourceBlob]);
+
+  // Parent blob (for diff viewer): either the source gallery item's full-res blob,
+  // or the original source blob if this turn edits the original.
+  const { parentBlob, parentLabel } = useMemo(() => {
+    if (turn.sourceItemId) {
+      const item = getItemById(turn.sourceItemId);
+      if (item && item.status === "completed") {
+        return { parentBlob: item.originalBlob, parentLabel: item.modelName };
+      }
+      return { parentBlob: null, parentLabel: undefined };
+    }
+    return { parentBlob: turn.sourceBlob ?? null, parentLabel: "Source" };
   }, [getItemById, turn.sourceItemId, turn.sourceBlob]);
 
   // Auto-select the first completed item in the most recent turn (once only)
@@ -93,6 +107,9 @@ export function Turn({ turn, turnIndex, isFirst = false }: TurnProps) {
                 modelName={item.modelName}
                 isSelected={isSelected}
                 onClick={() => selectItem(item.id)}
+                childBlob={item.originalBlob}
+                parentBlob={parentBlob}
+                parentLabel={parentLabel}
               />
             );
           }
@@ -110,15 +127,22 @@ function EditorImageCard({
   isSelected,
   onClick,
   itemId,
+  childBlob,
+  parentBlob,
+  parentLabel,
 }: {
   thumbnailUrl: string;
   modelName: string;
   isSelected: boolean;
   onClick: () => void;
   itemId: string;
+  childBlob: Blob;
+  parentBlob: Blob | null;
+  parentLabel?: string;
 }) {
   const [isLoaded, setIsLoaded] = useState(false);
   const openLightbox = useLightboxStore((s) => s.openLightbox);
+  const openDiff = useDiffStore((s) => s.openDiff);
 
   return (
     <button
@@ -148,25 +172,55 @@ function EditorImageCard({
         {modelName}
       </div>
 
-      {/* Lightbox button */}
-      <div
-        className="absolute top-2 left-2 z-10 opacity-0 transition-opacity duration-150 group-hover:opacity-100"
-        onClick={(e) => {
-          e.stopPropagation();
-          openLightbox({ kind: "gallery", imageId: itemId });
-        }}
-      >
-        <div className="flex h-7 w-7 items-center justify-center rounded-md bg-black/60 backdrop-blur-sm">
-          <Maximize2 className="h-4 w-4 text-white/80" />
+      {/* Toolbar */}
+      <div className="absolute top-2 left-2 z-10 flex items-center gap-1.5">
+        {/* Selection indicator (always visible) */}
+        <div
+          className={`flex h-7 w-7 items-center justify-center rounded-md backdrop-blur-sm ${
+            isSelected ? "bg-purple-500" : "bg-black/60"
+          }`}
+        >
+          {isSelected ? (
+            <Check className="h-4 w-4 text-white" />
+          ) : (
+            <Square className="h-4 w-4 text-white/80" />
+          )}
         </div>
-      </div>
 
-      {/* Selection checkmark */}
-      {isSelected && (
-        <div className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-md bg-purple-500">
-          <Check className="h-4 w-4 text-white" />
+        {/* Maximize button (hover only) */}
+        <div
+          className="opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation();
+            openLightbox({ kind: "gallery", imageId: itemId });
+          }}
+        >
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-black/60 backdrop-blur-sm">
+            <Maximize2 className="h-4 w-4 text-white/80" />
+          </div>
         </div>
-      )}
+
+        {/* Diff button (hover only) */}
+        {parentBlob && (
+          <div
+            className="opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+            onClick={(e) => {
+              e.stopPropagation();
+              openDiff({
+                parentBlob,
+                childBlob,
+                parentLabel,
+                childLabel: modelName,
+              });
+            }}
+            title="Compare with source"
+          >
+            <div className="flex h-7 w-7 items-center justify-center rounded-md bg-black/60 backdrop-blur-sm">
+              <Layers2 className="h-4 w-4 text-white/80" />
+            </div>
+          </div>
+        )}
+      </div>
 
       {/* Hover overlay hint when not selected */}
       {!isSelected && (

--- a/app/stores/diffStore.ts
+++ b/app/stores/diffStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+
+export interface DiffTarget {
+  parentBlob: Blob;
+  childBlob: Blob;
+  parentLabel?: string;
+  childLabel?: string;
+}
+
+interface DiffState {
+  isOpen: boolean;
+  target: DiffTarget | null;
+  openDiff: (target: DiffTarget) => void;
+  closeDiff: () => void;
+}
+
+export const useDiffStore = create<DiffState>()((set) => ({
+  isOpen: false,
+  target: null,
+
+  openDiff: (target) => set({ target, isOpen: true }),
+
+  closeDiff: () => set({ isOpen: false, target: null }),
+}));


### PR DESCRIPTION
## Summary
Adds a new image diff viewer component that allows users to compare generated images with their source images using an interactive side-by-side slider interface.

## Key Changes
- **New DiffViewer component** (`app/components/editor/DiffViewer.tsx`): A modal-based image comparison tool featuring:
  - Interactive slider to compare two images side-by-side
  - Pointer/touch support for dragging the divider
  - Keyboard support (Escape to close)
  - Responsive design with aspect ratio preservation
  - Visual labels for before/after images
  - Drag handle with visual feedback

- **New diff store** (`app/stores/diffStore.ts`): Zustand-based state management for:
  - Opening/closing the diff viewer
  - Managing the target images and labels to compare

- **Updated Turn component** (`app/components/editor/Turn.tsx`):
  - Added diff button to image cards (appears on hover)
  - Integrated with diff store to pass parent/child blobs
  - Calculates parent blob from source gallery item or original source
  - Updated toolbar layout to show selection indicator, maximize, and diff buttons

- **Integrated DiffViewer into EditorView** (`app/components/editor/EditorView.tsx`):
  - Added DiffViewer component to the editor layout

## Implementation Details
- Uses `URL.createObjectURL()` for efficient blob-to-image-URL conversion with proper cleanup
- Implements pointer capture for smooth dragging without event bubbling
- Aspect ratio is calculated from the parent image to maintain proportions
- The child image is clipped using CSS `clipPath` to create the slider effect
- Supports both mouse and touch interactions with proper pointer event handling

https://claude.ai/code/session_01Tk3kG8sKRvGYZaC1J8XA56