### PR TITLE
Add search functionality to gallery with prompt and model filtering

### DIFF
--- a/app/components/gallery/Gallery.tsx
+++ b/app/components/gallery/Gallery.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useGalleryStore } from "~/stores/galleryStore";
 import { GalleryHeader } from "./GalleryHeader";
 import { MasonryGrid, MasonryFrame } from "./MasonryGrid";
@@ -7,7 +7,7 @@ import { TimelineDivider } from "./TimelineDivider";
 import { ImageOff, Download, Trash2, X, ImagePlus } from "lucide-react";
 import type { GalleryItem } from "~/types";
 import { formatRelativeDate } from "~/lib/util";
-import { getFirstCreatedAt } from "~/lib/galleryGrouping";
+import { getFirstCreatedAt, groupItemsByPrompt } from "~/lib/galleryGrouping";
 import { stripVariationSections } from "~/lib/promptVariations";
 import NumberFlow from "@number-flow/react";
 import { useAttachSelectedItemsToGeneration } from "~/hooks/useAttachSelectedItemsToGeneration";
@@ -21,7 +21,25 @@ export function Gallery({ viewMode }: { viewMode: "grid" | "timeline" }) {
   const isLoadingMore = useGalleryStore((s) => s.isLoadingMore);
   const loadMoreImages = useGalleryStore((s) => s.loadMoreImages);
   const totalCount = useGalleryStore((s) => s.totalCount);
+  const searchQuery = useGalleryStore((s) => s.searchQuery);
+  const setSearchQuery = useGalleryStore((s) => s.setSearchQuery);
   const { itemsByPrompt } = useGalleryDerivedIndexes();
+
+  const filteredItems = useMemo(() => {
+    if (!searchQuery.trim()) return items;
+    const q = searchQuery.trim().toLowerCase();
+    return items.filter(
+      (item) =>
+        item.prompt.toLowerCase().includes(q) ||
+        (item.basePrompt?.toLowerCase().includes(q) ?? false) ||
+        item.modelName.toLowerCase().includes(q)
+    );
+  }, [items, searchQuery]);
+
+  const filteredItemsByPrompt = useMemo(
+    () => (searchQuery.trim() ? groupItemsByPrompt(filteredItems) : itemsByPrompt),
+    [filteredItems, itemsByPrompt, searchQuery]
+  );
 
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -48,15 +66,19 @@ export function Gallery({ viewMode }: { viewMode: "grid" | "timeline" }) {
 
   return (
     <main className="relative flex h-full flex-1 flex-col overflow-hidden bg-zinc-950">
-      <GalleryHeader count={totalCount} />
+      <GalleryHeader
+        count={searchQuery.trim() ? filteredItems.length : totalCount}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+      />
 
       <div className={`flex-1 overflow-y-auto p-2 md:p-6 ${selectedCount > 0 ? "pb-28" : ""}`}>
-        {items.length === 0 ? (
-          <EmptyState />
+        {filteredItems.length === 0 ? (
+          searchQuery.trim() ? <NoSearchResults /> : <EmptyState />
         ) : viewMode === "grid" ? (
-          <GridView items={items} />
+          <GridView items={filteredItems} />
         ) : (
-          <TimelineView itemsByPrompt={itemsByPrompt} />
+          <TimelineView itemsByPrompt={filteredItemsByPrompt} />
         )}
 
         <div ref={sentinelRef} className="h-1" />
@@ -163,6 +185,20 @@ function PopupActionButton({
       {icon}
       {label}
     </button>
+  );
+}
+
+function NoSearchResults() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center text-center">
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-zinc-900">
+        <ImageOff className="h-8 w-8 text-zinc-600" />
+      </div>
+      <h3 className="mb-2 text-lg font-medium text-zinc-300">No results</h3>
+      <p className="max-w-xs text-sm text-zinc-500">
+        No images match your search. Try a different prompt or model name.
+      </p>
+    </div>
   );
 }
 

--- a/app/components/gallery/GalleryHeader.tsx
+++ b/app/components/gallery/GalleryHeader.tsx
@@ -1,13 +1,16 @@
 import { LayoutDashboard, GalleryVertical, Settings, FilePenLine } from "lucide-react";
 import NumberFlow from "@number-flow/react";
 import { useLocation, useNavigate } from "react-router";
+import { SearchBar } from "./SearchBar";
 
 interface GalleryHeaderProps {
   count?: number;
   title?: string;
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
 }
 
-export function GalleryHeader({ count = 0, title }: GalleryHeaderProps) {
+export function GalleryHeader({ count = 0, title, searchQuery, onSearchChange }: GalleryHeaderProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -36,7 +39,15 @@ export function GalleryHeader({ count = 0, title }: GalleryHeaderProps) {
         )}
       </h2>
 
-      <div className="flex-1" />
+      {onSearchChange ? (
+        <div className="flex-1 px-4">
+          <div className="mx-auto max-w-sm">
+            <SearchBar value={searchQuery ?? ""} onChange={onSearchChange} />
+          </div>
+        </div>
+      ) : (
+        <div className="flex-1" />
+      )}
 
       <div className="flex items-center gap-1">
         <div className="flex items-center gap-1 rounded-lg bg-zinc-900 p-1">

--- a/app/components/gallery/SearchBar.tsx
+++ b/app/components/gallery/SearchBar.tsx
@@ -1,0 +1,30 @@
+import { Search, X } from "lucide-react";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function SearchBar({ value, onChange }: SearchBarProps) {
+  return (
+    <div className="relative flex items-center">
+      <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500" />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search prompts..."
+        className={`h-8 w-full rounded-lg border border-zinc-700 bg-zinc-900 py-1.5 text-sm text-zinc-100 placeholder-zinc-500 transition-colors focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none ${value ? "pl-8 pr-7" : "pl-8 pr-3"}`}
+      />
+      {value && (
+        <button
+          onClick={() => onChange("")}
+          aria-label="Clear search"
+          className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-200"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/stores/galleryStore.ts
+++ b/app/stores/galleryStore.ts
@@ -25,6 +25,7 @@ interface GalleryState {
   hasMore: boolean;
   isLoadingMore: boolean;
   totalCount: number;
+  searchQuery: string;
 
   loadImages: () => Promise<void>;
   loadMoreImages: () => Promise<void>;
@@ -42,6 +43,7 @@ interface GalleryState {
   clearSelection: () => void;
   deleteSelectedItems: () => Promise<number>;
   downloadSelectedItems: () => number;
+  setSearchQuery: (query: string) => void;
 }
 
 export const useGalleryStore = create<GalleryState>()((set, get) => ({
@@ -54,6 +56,7 @@ export const useGalleryStore = create<GalleryState>()((set, get) => ({
   hasMore: false,
   isLoadingMore: false,
   totalCount: 0,
+  searchQuery: "",
 
   loadImages: async () => {
     set({ isLoading: true });
@@ -215,6 +218,8 @@ export const useGalleryStore = create<GalleryState>()((set, get) => ({
     }),
 
   clearSelection: () => set({ selectedItemIds: [], lastSelectedId: null }),
+
+  setSearchQuery: (query) => set({ searchQuery: query }),
 
   deleteSelectedItems: async () => {
     const state = get();


### PR DESCRIPTION
## Summary
This PR adds a search feature to the gallery that allows users to filter images by prompt text and model name. The search is integrated into the gallery header and provides real-time filtering across both grid and timeline views.

## Key Changes
- **New SearchBar component** (`SearchBar.tsx`): A reusable search input with clear button and icon, styled to match the gallery UI
- **Gallery search state**: Added `searchQuery` state to `galleryStore` with `setSearchQuery` action to manage search input
- **Filtered results**: Implemented `useMemo` hooks in Gallery component to efficiently filter items by:
  - Prompt text (case-insensitive)
  - Base prompt text (if available)
  - Model name
- **Updated GalleryHeader**: Integrated SearchBar component with conditional rendering based on whether search callbacks are provided
- **No results state**: Added `NoSearchResults` component to display when search yields no matches
- **Timeline view support**: Filtered items are properly grouped by prompt for timeline view using `groupItemsByPrompt`
- **Dynamic count display**: Gallery header now shows filtered item count when searching, total count otherwise

## Implementation Details
- Search filtering is case-insensitive and trims whitespace
- When no search query is active, the gallery displays all items and uses the pre-computed `itemsByPrompt` index
- When searching, items are filtered first, then regrouped for timeline view to maintain consistency
- The search bar only appears in the main Gallery component (not in other uses of GalleryHeader)
- Clear button appears in search input only when there's an active search query

https://claude.ai/code/session_01W6Gz6cg8YfdgkykUeXd1s5