### PR TITLE
Add URL hash synchronization for lightbox gallery navigation

### DIFF
--- a/app/hooks/useLightboxUrlSync.ts
+++ b/app/hooks/useLightboxUrlSync.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from "react";
+import { useLightboxStore } from "~/stores/lightboxStore";
+import { useGalleryStore } from "~/stores/galleryStore";
+
+const HASH_PREFIX = "#img-";
+
+export function useLightboxUrlSync() {
+  const lightboxTarget = useLightboxStore((s) => s.lightboxTarget);
+  const setLightboxTarget = useLightboxStore((s) => s.setLightboxTarget);
+  const closeLightbox = useLightboxStore((s) => s.closeLightbox);
+  const items = useGalleryStore((s) => s.items);
+  const hasLoaded = useGalleryStore((s) => s.hasLoaded);
+
+  // Keep a ref so the popstate handler always sees fresh items without re-registering
+  const itemsRef = useRef(items);
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  // Sync lightboxTarget → URL hash
+  useEffect(() => {
+    if (lightboxTarget?.kind === "gallery") {
+      const newHash = HASH_PREFIX + lightboxTarget.imageId;
+      if (window.location.hash !== newHash) {
+        history.pushState(null, "", newHash);
+      }
+    } else if (!lightboxTarget && window.location.hash.startsWith(HASH_PREFIX)) {
+      history.replaceState(null, "", window.location.pathname + window.location.search);
+    }
+  }, [lightboxTarget]);
+
+  // Sync URL hash → lightboxTarget (handles Back/Forward)
+  useEffect(() => {
+    const handlePopState = () => {
+      const hash = window.location.hash;
+      if (hash.startsWith(HASH_PREFIX)) {
+        const imageId = hash.slice(HASH_PREFIX.length);
+        const item = itemsRef.current.find((i) => i.id === imageId && i.status === "completed");
+        if (item) {
+          setLightboxTarget({ kind: "gallery", imageId });
+        } else {
+          closeLightbox();
+          history.replaceState(null, "", window.location.pathname + window.location.search);
+        }
+      } else {
+        closeLightbox();
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [setLightboxTarget, closeLightbox]);
+
+  // Open lightbox from URL hash on initial load (handles reload / direct navigation)
+  const hasHandledInitialHash = useRef(false);
+  useEffect(() => {
+    if (!hasLoaded || hasHandledInitialHash.current) return;
+    const hash = window.location.hash;
+    if (!hash.startsWith(HASH_PREFIX)) return;
+    const imageId = hash.slice(HASH_PREFIX.length);
+    const item = items.find((i) => i.id === imageId && i.status === "completed");
+    if (item) {
+      hasHandledInitialHash.current = true;
+      setLightboxTarget({ kind: "gallery", imageId });
+    }
+  }, [hasLoaded, items, setLightboxTarget]);
+}

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -9,6 +9,7 @@ import { useGalleryStore } from "~/stores/galleryStore";
 import { useLightboxStore } from "~/stores/lightboxStore";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { useGalleryDerivedIndexes } from "~/hooks/useGalleryDerivedIndexes";
+import { useLightboxUrlSync } from "~/hooks/useLightboxUrlSync";
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -23,6 +24,7 @@ export default function Home() {
   const isLightboxOpen = useLightboxStore((s) => s.isLightboxOpen);
   const desktopNotificationsEnabled = useSettingsStore((s) => s.desktopNotificationsEnabled);
   const { inFlightCount } = useGalleryDerivedIndexes();
+  useLightboxUrlSync();
   const previousInFlightCountRef = useRef(0);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
This PR adds URL hash synchronization for the lightbox gallery feature, enabling users to share direct links to specific gallery images and use browser back/forward navigation within the lightbox.

## Key Changes
- **New hook `useLightboxUrlSync`**: Manages bidirectional synchronization between the lightbox state and URL hash
  - Syncs lightbox target to URL hash (e.g., `#img-123`) when an image is opened
  - Syncs URL hash back to lightbox state when using browser back/forward buttons
  - Handles initial page load/reload by opening the lightbox if a valid image hash is present
  - Uses refs to avoid stale closures in event handlers

- **Updated `home.tsx`**: Integrated the new hook into the Home component to enable URL sync functionality

## Implementation Details
- Uses `#img-` prefix for image hash identifiers to avoid conflicts with other hash-based routing
- Validates that images exist and have completed status before opening the lightbox
- Cleans up URL hash when lightbox is closed to maintain clean history
- Handles edge cases like invalid image IDs or missing items gracefully by closing the lightbox
- Uses `itemsRef` to ensure the popstate handler always accesses fresh gallery items without re-registering listeners

https://claude.ai/code/session_01KdtaaFLkzKbfW8TUZYRMGU