### PR TITLE
Add custom text model support with selection UI

### DIFF
--- a/app/components/settings/AddCustomTextModelButton.tsx
+++ b/app/components/settings/AddCustomTextModelButton.tsx
@@ -1,0 +1,147 @@
+import { Plus, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { useSettingsStore } from "~/stores/settingsStore";
+import { testTextModel } from "~/lib/textModel";
+import type { ApiKeyProvider } from "~/types";
+
+export default function AddCustomTextModelButton() {
+  const apiKeys = useSettingsStore((s) => s.apiKeys);
+  const textModels = useSettingsStore((s) => s.textModels);
+  const addCustomTextModel = useSettingsStore((s) => s.addCustomTextModel);
+
+  const defaultProvider: ApiKeyProvider = apiKeys.google
+    ? "google"
+    : apiKeys.replicate
+      ? "replicate"
+      : "google";
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [provider, setProvider] = useState<ApiKeyProvider>(defaultProvider);
+  const [modelId, setModelId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string>("");
+
+  const disabled = !apiKeys.google && !apiKeys.replicate;
+
+  const reset = () => {
+    setIsAdding(false);
+    setModelId("");
+    setError(null);
+    setStatus("");
+    setProvider(defaultProvider);
+  };
+
+  const handleAdd = async () => {
+    const trimmed = modelId.trim();
+    if (!trimmed) return;
+
+    if (provider === "replicate" && !trimmed.includes("/")) {
+      setError("Replicate model IDs look like 'owner/model-name'");
+      return;
+    }
+
+    const id = `${provider}:${trimmed}`;
+    if (textModels.some((m) => m.id === id)) {
+      setError("Model already added");
+      return;
+    }
+
+    const apiKey = apiKeys[provider];
+    if (!apiKey) {
+      setError(`Add a ${provider === "google" ? "Google" : "Replicate"} API key first`);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setStatus("Testing model...");
+
+    try {
+      await testTextModel(provider, apiKey, trimmed);
+      addCustomTextModel(
+        provider,
+        trimmed,
+        trimmed,
+        provider === "google" ? "/icons/google.svg" : undefined
+      );
+      reset();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to reach model");
+    } finally {
+      setLoading(false);
+      setStatus("");
+    }
+  };
+
+  if (!isAdding) {
+    return (
+      <button
+        onClick={() => setIsAdding(true)}
+        disabled={disabled}
+        className={`flex w-full items-center gap-2 rounded-lg border border-dashed border-zinc-700 p-2.5 text-zinc-400 transition-colors ${
+          disabled ? "cursor-not-allowed opacity-50" : "hover:border-zinc-600 hover:text-zinc-300"
+        }`}
+      >
+        <Plus className="h-4 w-4" />
+        <span className="text-sm">Add custom text model</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-lg border border-zinc-700 bg-zinc-800/50 p-3">
+      <div className="space-y-1">
+        <label className="block text-xs font-medium text-zinc-300">Provider</label>
+        <select
+          value={provider}
+          onChange={(e) => {
+            setProvider(e.target.value as ApiKeyProvider);
+            setError(null);
+          }}
+          className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
+        >
+          <option value="google">Google</option>
+          <option value="replicate">Replicate</option>
+        </select>
+      </div>
+      <div className="space-y-1">
+        <label className="block text-xs font-medium text-zinc-300">Model ID</label>
+        <input
+          type="text"
+          value={modelId}
+          onChange={(e) => {
+            setModelId(e.target.value);
+            setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !loading) handleAdd();
+          }}
+          placeholder={provider === "google" ? "gemini-3-flash-preview" : "owner/model-name"}
+          className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
+          autoFocus
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          onClick={handleAdd}
+          disabled={loading || !modelId.trim()}
+          className="flex items-center justify-center gap-1.5 rounded-lg bg-purple-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:bg-zinc-700 disabled:text-zinc-500"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+          Add
+        </button>
+        <button
+          onClick={reset}
+          className="rounded-lg bg-zinc-700 px-3 py-2 text-sm font-medium text-zinc-300 transition-colors hover:bg-zinc-600"
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+      <p className="text-xs text-zinc-500">
+        {status || "A quick test generation runs before saving to verify the model works."}
+      </p>
+    </div>
+  );
+}

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -37,10 +37,8 @@ const providers: { id: ApiKeyProvider; name: string; description: string; link: 
 
 export function SettingsModal() {
   const apiKeys = useSettingsStore((s) => s.apiKeys);
-  const textModel = useSettingsStore((s) => s.textModel);
   const desktopNotificationsEnabled = useSettingsStore((s) => s.desktopNotificationsEnabled);
   const setApiKey = useSettingsStore((s) => s.setApiKey);
-  const setTextModel = useSettingsStore((s) => s.setTextModel);
   const editorContextInjectionEnabled = useSettingsStore((s) => s.editorContextInjectionEnabled);
   const alwaysImprovePromptEnabled = useSettingsStore((s) => s.alwaysImprovePromptEnabled);
   const setDesktopNotificationsEnabled = useSettingsStore((s) => s.setDesktopNotificationsEnabled);
@@ -190,12 +188,12 @@ export function SettingsModal() {
           </div>
         </details>
 
-        {/* Text Model Section */}
+        {/* Text Generation Section */}
         <details className="group space-y-3" open>
           <summary className="flex w-full cursor-pointer list-none items-center justify-between text-left [&::-webkit-details-marker]:hidden">
             <div className="flex items-center gap-2">
               <MessageSquareText className="h-4 w-4 text-purple-400" />
-              <span className="text-sm font-medium">Text model</span>
+              <span className="text-sm font-medium">Text generation</span>
               {(apiKeys.google || apiKeys.replicate) && (
                 <Check className="h-4 w-4 text-green-500" />
               )}
@@ -205,50 +203,10 @@ export function SettingsModal() {
 
           <div className="ml-6 space-y-3 rounded-lg border border-zinc-800 bg-zinc-900/60 p-3">
             <p className="text-xs text-zinc-500">
-              Used for prompt improvement, variations, editor context briefs, and smart model
-              configuration.
+              The active text model is chosen in the sidebar. These settings control how it's used.
             </p>
 
-            <div className="space-y-2">
-              <label className="block text-xs font-medium text-zinc-300">Provider</label>
-              <select
-                value={textModel.provider}
-                onChange={(e) =>
-                  setTextModel({
-                    ...textModel,
-                    provider: e.target.value as ApiKeyProvider,
-                    modelId:
-                      e.target.value === "google"
-                        ? "gemini-3-flash-preview"
-                        : "google/gemini-3-flash",
-                  })
-                }
-                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 transition-colors focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
-              >
-                <option value="google">Google AI</option>
-                <option value="replicate">Replicate</option>
-              </select>
-            </div>
-
-            <div className="space-y-2">
-              <label className="block text-xs font-medium text-zinc-300">Model ID</label>
-              <input
-                type="text"
-                value={textModel.modelId}
-                onChange={(e) => setTextModel({ ...textModel, modelId: e.target.value })}
-                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 transition-colors focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
-              />
-            </div>
-
-            {!apiKeys[textModel.provider] && (
-              <p className="text-xs text-amber-400">
-                {apiKeys[textModel.provider === "google" ? "replicate" : "google"]
-                  ? `No ${textModel.provider === "google" ? "Google" : "Replicate"} key — will fall back to ${textModel.provider === "google" ? "Replicate" : "Google"}.`
-                  : "No API keys configured. Add one above to enable text model features."}
-              </p>
-            )}
-
-            <div className="space-y-3 border-t border-zinc-800 pt-3">
+            <div className="space-y-3">
               <label className="flex items-center justify-between gap-3">
                 <span className="text-sm text-zinc-200">Always improve prompt</span>
                 <Switch

--- a/app/components/settings/TextModelItem.tsx
+++ b/app/components/settings/TextModelItem.tsx
@@ -1,0 +1,90 @@
+import { Trash2, Box, Check } from "lucide-react";
+import { useSettingsStore } from "~/stores/settingsStore";
+import SVG from "react-inlinesvg";
+import type { StoredTextModel } from "~/types";
+import { Tooltip } from "~/components/ui/Tooltip";
+
+export default function TextModelItem({
+  model,
+  hasApiKey,
+}: {
+  model: StoredTextModel;
+  hasApiKey: boolean;
+}) {
+  const selectTextModel = useSettingsStore((s) => s.selectTextModel);
+  const removeCustomTextModel = useSettingsStore((s) => s.removeCustomTextModel);
+
+  const handleSelect = () => {
+    if (!hasApiKey) return;
+    if (model.enabled) return;
+    selectTextModel(model.id);
+  };
+
+  return (
+    <div
+      className={`flex items-center gap-1 rounded-lg border p-2.5 transition-colors ${
+        model.enabled
+          ? "border-purple-600/50 bg-purple-900/20"
+          : "border-zinc-700/50 bg-zinc-800/50"
+      } ${!hasApiKey ? "opacity-50" : ""}`}
+    >
+      <button
+        type="button"
+        role="radio"
+        aria-checked={model.enabled}
+        onClick={handleSelect}
+        disabled={!hasApiKey}
+        className="flex min-w-0 flex-1 items-center gap-2 text-left disabled:cursor-not-allowed"
+      >
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-zinc-700 text-zinc-400">
+          {model.icon ? <SVG src={model.icon} className="h-5 w-5" /> : <Box className="h-4 w-4" />}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-zinc-100">{model.name}</p>
+          <div className="mt-0.5 flex items-center gap-1">
+            <Tooltip
+              content={model.provider === "google" ? "Google" : "Replicate"}
+              placement="top"
+              delay={200}
+            >
+              <span className="text-zinc-40 inline-flex cursor-help items-center gap-1 rounded bg-purple-700/50 px-1.5 py-0.5 text-[10px] text-purple-400">
+                <SVG
+                  src={`/icons/${model.provider}.svg`}
+                  className="h-2.5 w-2.5 overflow-visible"
+                />
+              </span>
+            </Tooltip>
+            <span className="truncate text-[10px] text-zinc-500">{model.modelId}</span>
+          </div>
+        </div>
+      </button>
+
+      {model.isCustom && (
+        <button
+          type="button"
+          onClick={() => removeCustomTextModel(model.id)}
+          className="shrink-0 p-1 text-zinc-500 transition-colors hover:text-red-400"
+          title="Remove model"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      )}
+
+      <button
+        type="button"
+        role="radio"
+        aria-checked={model.enabled}
+        onClick={handleSelect}
+        disabled={!hasApiKey}
+        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors disabled:cursor-not-allowed ${
+          model.enabled
+            ? "border-purple-500 bg-purple-500 text-white"
+            : "border-zinc-600 hover:border-zinc-500"
+        }`}
+        aria-label={`Select ${model.name}`}
+      >
+        {model.enabled && <Check className="h-3 w-3" strokeWidth={3} />}
+      </button>
+    </div>
+  );
+}

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Layers, X } from "lucide-react";
+import { Layers, MessageSquareText, X } from "lucide-react";
 import { useLocation } from "react-router";
 import { PromptInput } from "./PromptInput";
 import { ModelList } from "./ModelList";
@@ -10,7 +10,9 @@ import { AvoidPastVariationsToggle } from "./AvoidPastVariationsToggle";
 import SVG from "react-inlinesvg";
 import drop from "~/drop.svg";
 import AddCustomModelButton from "../settings/AddCustomModelButton";
+import AddCustomTextModelButton from "../settings/AddCustomTextModelButton";
 import SortableModelItem from "../settings/SortableModelItem";
+import TextModelItem from "../settings/TextModelItem";
 import { hasProviderAccess } from "~/lib/providers";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { useCallback } from "react";
@@ -75,6 +77,7 @@ function EditorSidebarContent() {
 
 function SettingsSidebarContent() {
   const models = useSettingsStore((s) => s.models);
+  const textModels = useSettingsStore((s) => s.textModels);
   const apiKeys = useSettingsStore((s) => s.apiKeys);
   const reorderModels = useSettingsStore((s) => s.reorderModels);
 
@@ -117,6 +120,25 @@ function SettingsSidebarContent() {
       </DndContext>
 
       <AddCustomModelButton disabled={!apiKeys.replicate} apiKey={apiKeys.replicate} />
+
+      <div className="flex items-center gap-2 pt-4">
+        <span className="text-zinc-500">
+          <MessageSquareText className="h-4 w-4" />
+        </span>
+        <h2 className="text-xs font-medium tracking-wide text-zinc-400 uppercase">Text Model</h2>
+      </div>
+
+      <div className="space-y-2">
+        {textModels.map((model) => (
+          <TextModelItem
+            key={model.id}
+            model={model}
+            hasApiKey={hasProviderAccess(apiKeys, model.provider)}
+          />
+        ))}
+      </div>
+
+      <AddCustomTextModelButton />
     </div>
   );
 }

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -1,4 +1,4 @@
-import type { StoredModel } from "~/types";
+import type { StoredModel, StoredTextModel } from "~/types";
 
 const BASE_BUILT_IN_MODELS: StoredModel[] = [
   {
@@ -234,4 +234,66 @@ export function mergeWithBuiltInModels(models?: StoredModel[]): StoredModel[] {
   const customModels = models.filter((model) => !isBuiltInModel(model.id));
 
   return [...mergedBuiltIns, ...customModels];
+}
+
+export const BUILT_IN_TEXT_MODELS: StoredTextModel[] = [
+  {
+    id: "google:gemini-3-flash-preview",
+    name: "Gemini 3 Flash Preview",
+    provider: "google",
+    modelId: "gemini-3-flash-preview",
+    enabled: true,
+    icon: "/icons/google.svg",
+  },
+  {
+    id: "replicate:google/gemini-3-flash",
+    name: "Gemini 3 Flash (Replicate)",
+    provider: "replicate",
+    modelId: "google/gemini-3-flash",
+    enabled: false,
+    icon: "/icons/google.svg",
+  },
+];
+
+const BUILT_IN_TEXT_MODEL_IDS = new Set(BUILT_IN_TEXT_MODELS.map((m) => m.id));
+
+export function isBuiltInTextModel(id: string): boolean {
+  return BUILT_IN_TEXT_MODEL_IDS.has(id);
+}
+
+export function mergeWithBuiltInTextModels(models?: StoredTextModel[]): StoredTextModel[] {
+  if (!models || models.length === 0) {
+    return BUILT_IN_TEXT_MODELS.map((m) => ({ ...m }));
+  }
+
+  const existingById = new Map(models.map((m) => [m.id, m]));
+
+  const mergedBuiltIns = BUILT_IN_TEXT_MODELS.map((builtIn) => {
+    const existing = existingById.get(builtIn.id);
+    if (!existing) return { ...builtIn };
+    return {
+      ...builtIn,
+      enabled: existing.enabled,
+    };
+  });
+
+  const customModels = models.filter((m) => !isBuiltInTextModel(m.id) && m.isCustom);
+
+  const merged = [...mergedBuiltIns, ...customModels];
+
+  // Ensure exactly one enabled: if zero, enable the first built-in; if multiple, keep first.
+  const enabledCount = merged.filter((m) => m.enabled).length;
+  if (enabledCount === 0 && merged.length > 0) {
+    merged[0] = { ...merged[0], enabled: true };
+  } else if (enabledCount > 1) {
+    let seenEnabled = false;
+    for (let i = 0; i < merged.length; i++) {
+      if (merged[i].enabled) {
+        if (seenEnabled) merged[i] = { ...merged[i], enabled: false };
+        else seenEnabled = true;
+      }
+    }
+  }
+
+  return merged;
 }

--- a/app/lib/textModel.ts
+++ b/app/lib/textModel.ts
@@ -16,19 +16,24 @@ interface ResolvedProvider {
 }
 
 function resolveProvider(): ResolvedProvider {
-  const { apiKeys, textModel } = useSettingsStore.getState();
+  const { apiKeys, textModels } = useSettingsStore.getState();
+  const selected = textModels.find((m) => m.enabled) ?? textModels[0];
 
-  // Try configured provider first
-  if (apiKeys[textModel.provider]) {
+  if (!selected) {
+    throw new Error("No text model configured");
+  }
+
+  // Try selected model's provider first
+  if (apiKeys[selected.provider]) {
     return {
-      provider: textModel.provider,
-      apiKey: apiKeys[textModel.provider]!,
-      modelId: textModel.modelId,
+      provider: selected.provider,
+      apiKey: apiKeys[selected.provider]!,
+      modelId: selected.modelId,
     };
   }
 
-  // Fallback to the other provider
-  const fallback: ApiKeyProvider = textModel.provider === "google" ? "replicate" : "google";
+  // Fallback to the other provider with its default model
+  const fallback: ApiKeyProvider = selected.provider === "google" ? "replicate" : "google";
   if (apiKeys[fallback]) {
     return {
       provider: fallback,
@@ -187,4 +192,23 @@ async function callReplicateTextModel(
   }
 
   throw new Error("Unexpected text model response format");
+}
+
+/**
+ * Validate that a text model can be called end-to-end. Used when adding a
+ * custom model so we fail fast on bad IDs or wrong providers. Bypasses the
+ * store and does NOT retry — a single fast attempt is what users expect here.
+ */
+export async function testTextModel(
+  provider: ApiKeyProvider,
+  apiKey: string,
+  modelId: string
+): Promise<void> {
+  const systemPrompt = "You are a connectivity test.";
+  const userPrompt = "Respond with the single word 'hi' and nothing else.";
+  if (provider === "google") {
+    await callGoogleTextModel(apiKey, modelId, systemPrompt, userPrompt);
+  } else {
+    await callReplicateTextModel(apiKey, modelId, systemPrompt, userPrompt);
+  }
 }

--- a/app/stores/settingsStore.ts
+++ b/app/stores/settingsStore.ts
@@ -1,6 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { BUILT_IN_MODELS, isBuiltInModel, mergeWithBuiltInModels } from "~/lib/builtInModels";
+import {
+  BUILT_IN_MODELS,
+  BUILT_IN_TEXT_MODELS,
+  isBuiltInModel,
+  mergeWithBuiltInModels,
+  mergeWithBuiltInTextModels,
+} from "~/lib/builtInModels";
 import { hasProviderAccess } from "~/lib/providers";
 import type {
   ApiKeyProvider,
@@ -9,13 +15,13 @@ import type {
   Provider,
   SchemaMapping,
   StoredModel,
-  TextModelConfig,
+  StoredTextModel,
 } from "~/types";
 
 interface SettingsState {
   apiKeys: ApiKeys;
   models: StoredModel[];
-  textModel: TextModelConfig;
+  textModels: StoredTextModel[];
   desktopNotificationsEnabled: boolean;
   notificationPromptDismissed: boolean;
   requestedOutputCount: number;
@@ -45,7 +51,14 @@ interface SettingsState {
   updateModelSchemaMapping: (id: string, schemaMapping: SchemaMapping) => void;
 
   // Text model actions
-  setTextModel: (config: TextModelConfig) => void;
+  selectTextModel: (id: string) => void;
+  addCustomTextModel: (
+    provider: ApiKeyProvider,
+    modelId: string,
+    name: string,
+    icon?: string
+  ) => void;
+  removeCustomTextModel: (id: string) => void;
 
   // Notification actions
   setDesktopNotificationsEnabled: (enabled: boolean) => void;
@@ -67,7 +80,7 @@ export const useSettingsStore = create<SettingsState>()(
         replicate: null,
       },
       models: BUILT_IN_MODELS,
-      textModel: { provider: "google", modelId: "gemini-3-flash-preview" },
+      textModels: BUILT_IN_TEXT_MODELS,
       desktopNotificationsEnabled: false,
       notificationPromptDismissed: false,
       requestedOutputCount: 0,
@@ -139,7 +152,45 @@ export const useSettingsStore = create<SettingsState>()(
           models: state.models.map((m) => (m.id === id ? { ...m, schemaMapping } : m)),
         })),
 
-      setTextModel: (config) => set({ textModel: config }),
+      selectTextModel: (id) =>
+        set((state) => {
+          if (!state.textModels.some((m) => m.id === id)) return state;
+          return {
+            textModels: state.textModels.map((m) => ({ ...m, enabled: m.id === id })),
+          };
+        }),
+
+      addCustomTextModel: (provider, modelId, name, icon) =>
+        set((state) => {
+          const id = `${provider}:${modelId}`;
+          if (state.textModels.some((m) => m.id === id)) return state;
+          const newModel: StoredTextModel = {
+            id,
+            name,
+            provider,
+            modelId,
+            enabled: true,
+            isCustom: true,
+            ...(icon && { icon }),
+          };
+          return {
+            textModels: [
+              ...state.textModels.map((m) => ({ ...m, enabled: false })),
+              newModel,
+            ],
+          };
+        }),
+
+      removeCustomTextModel: (id) =>
+        set((state) => {
+          const target = state.textModels.find((m) => m.id === id);
+          if (!target || !target.isCustom) return state;
+          const remaining = state.textModels.filter((m) => m.id !== id);
+          if (target.enabled && remaining.length > 0) {
+            remaining[0] = { ...remaining[0], enabled: true };
+          }
+          return { textModels: remaining };
+        }),
 
       setDesktopNotificationsEnabled: (enabled) => set({ desktopNotificationsEnabled: enabled }),
 
@@ -158,11 +209,11 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: "studio-settings",
-      version: 10,
+      version: 11,
       partialize: (state) => ({
         apiKeys: state.apiKeys,
         models: state.models,
-        textModel: state.textModel,
+        textModels: state.textModels,
         desktopNotificationsEnabled: state.desktopNotificationsEnabled,
         notificationPromptDismissed: state.notificationPromptDismissed,
         requestedOutputCount: state.requestedOutputCount,
@@ -173,7 +224,8 @@ export const useSettingsStore = create<SettingsState>()(
         let state = persisted as {
           apiKeys?: ApiKeys;
           models?: StoredModel[];
-          textModel?: TextModelConfig;
+          textModel?: { provider: ApiKeyProvider; modelId: string };
+          textModels?: StoredTextModel[];
           desktopNotificationsEnabled?: boolean;
           notificationPromptDismissed?: boolean;
           requestedOutputCount?: number;
@@ -235,6 +287,38 @@ export const useSettingsStore = create<SettingsState>()(
             textModel: { provider: "google", modelId: "gemini-3-flash-preview" },
           };
         }
+
+        if (version < 11) {
+          // Convert scalar textModel into textModels list.
+          const prev = state.textModel;
+          const seed = BUILT_IN_TEXT_MODELS.map((m) => ({ ...m, enabled: false }));
+          if (prev) {
+            const prevId = `${prev.provider}:${prev.modelId}`;
+            const existing = seed.find((m) => m.id === prevId);
+            if (existing) {
+              existing.enabled = true;
+            } else {
+              seed.push({
+                id: prevId,
+                name: prev.modelId,
+                provider: prev.provider,
+                modelId: prev.modelId,
+                enabled: true,
+                isCustom: true,
+                ...(prev.provider === "google" ? { icon: "/icons/google.svg" } : {}),
+              });
+            }
+          } else {
+            seed[0] = { ...seed[0], enabled: true };
+          }
+          state = { ...state, textModels: seed, textModel: undefined };
+        }
+
+        // always update builtin text models
+        state = {
+          ...state,
+          textModels: mergeWithBuiltInTextModels(state.textModels),
+        };
 
         state = {
           ...state,

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -152,9 +152,14 @@ export interface AttachSelectedItemsResult {
 }
 
 // Text model types
-export interface TextModelConfig {
+export interface StoredTextModel {
+  id: string; // stable unique id, e.g. "google:gemini-3-flash-preview" or "replicate:google/gemini-3-flash"
+  name: string;
   provider: ApiKeyProvider;
-  modelId: string;
+  modelId: string; // SDK model identifier
+  enabled: boolean; // exactly one is true at a time
+  isCustom?: boolean;
+  icon?: string;
 }
 
 export interface SchemaMapping {


### PR DESCRIPTION
## Summary
This PR refactors text model management from a single configured model to a list-based system with built-in and custom model support. Users can now add custom text models, select between multiple models, and manage them through an improved sidebar UI.

## Key Changes

- **Text Model Storage Refactor**: Changed from scalar `textModel` config to `textModels` array in settings store, allowing multiple models with exactly one enabled at a time
- **Custom Text Model Support**: Added ability to add custom Google and Replicate text models with validation via `testTextModel()` function
- **New UI Components**:
  - `AddCustomTextModelButton`: Form to add custom models with provider selection, model ID input, and test validation
  - `TextModelItem`: Radio-button style selector for text models with provider badges and delete option for custom models
- **Built-in Models**: Defined `BUILT_IN_TEXT_MODELS` with Gemini 3 Flash (Google and Replicate variants) and merge logic to preserve user selections
- **Settings Migration**: Added version 11 migration to convert legacy `textModel` scalar into `textModels` list, preserving user's previous selection
- **Sidebar Integration**: Moved text model selection from settings modal to sidebar under new "Text Model" section, making it more discoverable
- **Provider Fallback**: Updated `resolveProvider()` to handle model selection and fallback to alternate provider if primary API key is missing

## Implementation Details

- Text model validation happens before saving via `testTextModel()` - a single fast attempt that fails immediately on bad IDs
- Exactly one text model is always enabled; adding a new model disables others and enables the new one
- Custom models are identified by `isCustom` flag and can only be deleted if custom
- Built-in models are automatically merged on store initialization to preserve user selections while updating available options
- Settings modal text generation section now focuses on usage settings rather than model configuration

close #31 

https://claude.ai/code/session_01YWQSYSqZKHUrZwHDJj6LGF