### PR TITLE
Add upscaler management UI with custom Replicate model support

### DIFF
--- a/app/components/lightbox/Lightbox.tsx
+++ b/app/components/lightbox/Lightbox.tsx
@@ -27,7 +27,6 @@ import {
   useReuseGalleryItemPrompt,
 } from "~/hooks/useReuseGalleryItemPrompt";
 import { useUpscale } from "~/hooks/useUpscale";
-import { getEnabledUpscalers } from "~/stores/settingsStore";
 import { IconButton } from "./IconButton";
 import { WideIconButton } from "./WideIconButton";
 import { findSessionForImage, getReferenceImagesByIds, saveReferenceImage } from "~/lib/db";
@@ -54,7 +53,8 @@ export function Lightbox() {
   const [showUpscalePicker, setShowUpscalePicker] = useState(false);
   const { status: upscaleStatus, error: upscaleError, upscale } = useUpscale();
   const replicateKey = useSettingsStore((s) => s.apiKeys.replicate);
-  const enabledUpscalers = useSettingsStore(getEnabledUpscalers);
+  const upscalers = useSettingsStore((s) => s.upscalers);
+  const enabledUpscalers = replicateKey ? upscalers.filter((u) => u.enabled) : [];
 
   useEffect(() => {
     if (!galleryImage || galleryImage.referenceImageIds.length === 0) {

--- a/app/components/lightbox/Lightbox.tsx
+++ b/app/components/lightbox/Lightbox.tsx
@@ -27,7 +27,7 @@ import {
   useReuseGalleryItemPrompt,
 } from "~/hooks/useReuseGalleryItemPrompt";
 import { useUpscale } from "~/hooks/useUpscale";
-import { UPSCALERS } from "~/lib/upscaling";
+import { getEnabledUpscalers } from "~/stores/settingsStore";
 import { IconButton } from "./IconButton";
 import { WideIconButton } from "./WideIconButton";
 import { findSessionForImage, getReferenceImagesByIds, saveReferenceImage } from "~/lib/db";
@@ -54,6 +54,7 @@ export function Lightbox() {
   const [showUpscalePicker, setShowUpscalePicker] = useState(false);
   const { status: upscaleStatus, error: upscaleError, upscale } = useUpscale();
   const replicateKey = useSettingsStore((s) => s.apiKeys.replicate);
+  const enabledUpscalers = useSettingsStore(getEnabledUpscalers);
 
   useEffect(() => {
     if (!galleryImage || galleryImage.referenceImageIds.length === 0) {
@@ -315,19 +316,25 @@ export function Lightbox() {
                 <div className="space-y-2 rounded-lg border border-zinc-700 bg-zinc-800/50 p-3">
                   <p className="text-xs font-medium text-zinc-400">Upscale with</p>
                   <div className="flex flex-wrap gap-1.5">
-                    {UPSCALERS.map((u) => (
-                      <button
-                        key={u.label}
-                        disabled={upscaleStatus === "running"}
-                        onClick={() => {
-                          upscale(galleryImage, u);
-                          setShowUpscalePicker(false);
-                        }}
-                        className="rounded-md bg-zinc-700 px-2.5 py-1 text-xs text-zinc-300 transition-colors hover:bg-zinc-600 disabled:cursor-not-allowed disabled:bg-zinc-700/50 disabled:text-zinc-600"
-                      >
-                        {u.label}
-                      </button>
-                    ))}
+                    {enabledUpscalers.length === 0 ? (
+                      <p className="text-xs text-zinc-500">
+                        No upscalers enabled. Enable or add one in Settings.
+                      </p>
+                    ) : (
+                      enabledUpscalers.map((u) => (
+                        <button
+                          key={u.id}
+                          disabled={upscaleStatus === "running"}
+                          onClick={() => {
+                            upscale(galleryImage, u);
+                            setShowUpscalePicker(false);
+                          }}
+                          className="rounded-md bg-zinc-700 px-2.5 py-1 text-xs text-zinc-300 transition-colors hover:bg-zinc-600 disabled:cursor-not-allowed disabled:bg-zinc-700/50 disabled:text-zinc-600"
+                        >
+                          {u.name}
+                        </button>
+                      ))
+                    )}
                   </div>
                   {upscaleStatus === "running" && (
                     <p className="text-xs text-zinc-500">Upscaling…</p>

--- a/app/components/settings/AddCustomUpscalerButton.tsx
+++ b/app/components/settings/AddCustomUpscalerButton.tsx
@@ -1,0 +1,191 @@
+import { Plus, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  inferIcon,
+  inferName,
+  searchReplicateModels,
+  type ReplicateSearchResult,
+} from "~/lib/replicateSchema";
+import SVG from "react-inlinesvg";
+import { useSettingsStore } from "~/stores/settingsStore";
+import { Combobox } from "@base-ui/react/combobox";
+
+export default function AddCustomUpscalerButton({
+  disabled,
+  apiKey,
+}: {
+  disabled?: boolean;
+  apiKey: string | null;
+}) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [modelId, setModelId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<ReplicateSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const addCustomUpscaler = useSettingsStore((s) => s.addCustomUpscaler);
+  const upscalers = useSettingsStore((s) => s.upscalers);
+
+  useEffect(() => {
+    if (!modelId.trim() || modelId.length < 2 || !apiKey || loading) {
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const results = await searchReplicateModels(modelId, apiKey);
+        setSuggestions(results);
+        setOpen(results.length > 0);
+      } catch {
+        // suggestions are best-effort
+      } finally {
+        setIsSearching(false);
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [modelId, apiKey]);
+
+  const handleAdd = async (altModelID?: string) => {
+    const idToAdd = altModelID ?? modelId;
+    if (!idToAdd.trim()) return;
+    setOpen(false);
+
+    if (!idToAdd.includes("/")) {
+      setError("Format: owner/model-name");
+      return;
+    }
+
+    const syntheticId = `replicate/${idToAdd}`;
+    if (upscalers.some((u) => u.id === syntheticId)) {
+      setError("Upscaler already added");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const name = inferName(idToAdd);
+      const icon = inferIcon(idToAdd);
+      addCustomUpscaler(idToAdd, name, icon);
+      setModelId("");
+      setIsAdding(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add upscaler");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isAdding) {
+    return (
+      <button
+        onClick={() => setIsAdding(true)}
+        disabled={disabled}
+        className={`flex w-full items-center gap-2 rounded-lg border border-dashed border-zinc-700 p-2.5 text-zinc-400 transition-colors ${
+          disabled ? "cursor-not-allowed opacity-50" : "hover:border-zinc-600 hover:text-zinc-300"
+        }`}
+      >
+        <Plus className="h-4 w-4" />
+        <span className="text-sm">Add custom Replicate upscaler</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-lg border border-zinc-700 bg-zinc-800/50 p-3">
+      <Combobox.Root
+        open={open}
+        onOpenChange={setOpen}
+        inputValue={modelId}
+        onInputValueChange={(val) => {
+          setModelId(val);
+          setError(null);
+        }}
+        onValueChange={(id) => {
+          if (id && !loading) handleAdd(id as string);
+        }}
+        filter={null}
+      >
+        <div className="relative">
+          <Combobox.Input
+            placeholder="Type to search..."
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !open && !loading) handleAdd();
+            }}
+            autoFocus
+          />
+          {isSearching && (
+            <Loader2 className="absolute top-2.5 right-2.5 h-4 w-4 animate-spin text-zinc-500" />
+          )}
+        </div>
+        <Combobox.Portal>
+          <Combobox.Positioner sideOffset={4} align="start">
+            <Combobox.Popup
+              className="z-50 max-h-72 overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-xl"
+              style={{ width: "var(--anchor-width)" }}
+            >
+              {suggestions.map((result) => {
+                const icon = inferIcon(result.id);
+                const owner = result.id.split("/")[0];
+                return (
+                  <Combobox.Item
+                    key={result.id}
+                    value={result.id}
+                    className="flex w-full cursor-default items-center gap-2.5 px-3 py-2 text-left outline-none data-[highlighted]:bg-zinc-800"
+                  >
+                    {icon ? (
+                      <SVG src={icon} className="h-5 w-5 shrink-0" />
+                    ) : (
+                      <div className="h-5 w-5 shrink-0 rounded bg-zinc-700" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-baseline gap-1.5">
+                        <p className="truncate text-sm font-medium text-zinc-100">{result.name}</p>
+                        <p className="shrink-0 text-xs text-zinc-500">{owner}</p>
+                      </div>
+                      {result.description && (
+                        <p className="truncate text-xs text-zinc-400">{result.description}</p>
+                      )}
+                    </div>
+                  </Combobox.Item>
+                );
+              })}
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          onClick={() => handleAdd()}
+          disabled={loading || !modelId.trim()}
+          className="flex items-center justify-center gap-1.5 rounded-lg bg-purple-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:bg-zinc-700 disabled:text-zinc-500"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+          Add
+        </button>
+        <button
+          onClick={() => {
+            setIsAdding(false);
+            setModelId("");
+            setError(null);
+            setSuggestions([]);
+            setOpen(false);
+          }}
+          className="rounded-lg bg-zinc-700 px-3 py-2 text-sm font-medium text-zinc-300 transition-colors hover:bg-zinc-600"
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+      <p className="text-xs text-zinc-500">
+        Type to search, or enter a Replicate model ID like &quot;nightmareai/real-esrgan&quot;.
+      </p>
+    </div>
+  );
+}

--- a/app/components/settings/SortableUpscalerItem.tsx
+++ b/app/components/settings/SortableUpscalerItem.tsx
@@ -1,0 +1,31 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import UpscalerItem from "./UpscalerItem";
+import type { StoredUpscaler } from "~/types";
+
+export default function SortableUpscalerItem({
+  upscaler,
+  hasApiKey,
+}: {
+  upscaler: StoredUpscaler;
+  hasApiKey: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: upscaler.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className={isDragging ? "relative z-50 opacity-75" : ""}>
+      <UpscalerItem
+        upscaler={upscaler}
+        hasApiKey={hasApiKey}
+        dragHandleProps={{ ...attributes, ...listeners }}
+      />
+    </div>
+  );
+}

--- a/app/components/settings/UpscalerItem.tsx
+++ b/app/components/settings/UpscalerItem.tsx
@@ -1,0 +1,70 @@
+import { GripVertical, Box, Trash2 } from "lucide-react";
+import { useSettingsStore } from "~/stores/settingsStore";
+import SVG from "react-inlinesvg";
+import type { StoredUpscaler } from "~/types";
+import { Tooltip } from "~/components/ui/Tooltip";
+import { Switch } from "~/components/ui/Switch";
+
+export default function UpscalerItem({
+  upscaler,
+  hasApiKey,
+  dragHandleProps,
+}: {
+  upscaler: StoredUpscaler;
+  hasApiKey: boolean;
+  dragHandleProps?: React.HTMLAttributes<HTMLButtonElement>;
+}) {
+  const setUpscalerEnabled = useSettingsStore((s) => s.setUpscalerEnabled);
+  const removeCustomUpscaler = useSettingsStore((s) => s.removeCustomUpscaler);
+
+  return (
+    <div
+      className={`flex items-center gap-1 rounded-lg border border-zinc-700/50 bg-zinc-800/50 p-2.5 ${
+        !hasApiKey ? "opacity-50" : ""
+      }`}
+    >
+      {dragHandleProps && (
+        <button
+          {...dragHandleProps}
+          className="mr-2 shrink-0 cursor-grab touch-none text-zinc-600 hover:text-zinc-400 active:cursor-grabbing"
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+      )}
+      <div className="mr-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-zinc-700 text-zinc-400">
+        {upscaler.icon ? (
+          <SVG src={upscaler.icon} className="h-5 w-5" />
+        ) : (
+          <Box className="h-4 w-4" />
+        )}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-zinc-100">{upscaler.name}</p>
+        <div className="mt-0.5 flex items-center gap-1">
+          <Tooltip content="Replicate" placement="top" delay={200}>
+            <span className="inline-flex cursor-help items-center gap-1 rounded bg-purple-700/50 px-1.5 py-0.5 text-[10px] text-purple-400">
+              <SVG src="/icons/replicate.svg" className="h-2.5 w-2.5 overflow-visible" />
+            </span>
+          </Tooltip>
+        </div>
+      </div>
+
+      {upscaler.isCustom && (
+        <button
+          onClick={() => removeCustomUpscaler(upscaler.id)}
+          className="shrink-0 p-1 text-zinc-500 transition-colors hover:text-red-400"
+          title="Remove upscaler"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      )}
+      <Switch
+        checked={upscaler.enabled}
+        onChange={(e) => setUpscalerEnabled(upscaler.id, e.target.checked)}
+        disabled={!hasApiKey}
+        aria-label={`Toggle ${upscaler.name}`}
+      />
+    </div>
+  );
+}

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Layers, MessageSquareText, X } from "lucide-react";
+import { Expand, Layers, MessageSquareText, X } from "lucide-react";
 import { useLocation } from "react-router";
 import { PromptInput } from "./PromptInput";
 import { ModelList } from "./ModelList";
@@ -11,7 +11,9 @@ import SVG from "react-inlinesvg";
 import drop from "~/drop.svg";
 import AddCustomModelButton from "../settings/AddCustomModelButton";
 import AddCustomTextModelButton from "../settings/AddCustomTextModelButton";
+import AddCustomUpscalerButton from "../settings/AddCustomUpscalerButton";
 import SortableModelItem from "../settings/SortableModelItem";
+import SortableUpscalerItem from "../settings/SortableUpscalerItem";
 import TextModelItem from "../settings/TextModelItem";
 import { hasProviderAccess } from "~/lib/providers";
 import { useSettingsStore } from "~/stores/settingsStore";
@@ -78,8 +80,10 @@ function EditorSidebarContent() {
 function SettingsSidebarContent() {
   const models = useSettingsStore((s) => s.models);
   const textModels = useSettingsStore((s) => s.textModels);
+  const upscalers = useSettingsStore((s) => s.upscalers);
   const apiKeys = useSettingsStore((s) => s.apiKeys);
   const reorderModels = useSettingsStore((s) => s.reorderModels);
+  const reorderUpscalers = useSettingsStore((s) => s.reorderUpscalers);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -94,6 +98,16 @@ function SettingsSidebarContent() {
       }
     },
     [reorderModels]
+  );
+
+  const handleUpscalerDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (over && active.id !== over.id) {
+        reorderUpscalers(active.id as string, over.id as string);
+      }
+    },
+    [reorderUpscalers]
   );
 
   return (
@@ -139,6 +153,36 @@ function SettingsSidebarContent() {
       </div>
 
       <AddCustomTextModelButton />
+
+      <div className="flex items-center gap-2 pt-4">
+        <span className="text-zinc-500">
+          <Expand className="h-4 w-4" />
+        </span>
+        <h2 className="text-xs font-medium tracking-wide text-zinc-400 uppercase">Upscalers</h2>
+      </div>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleUpscalerDragEnd}
+      >
+        <SortableContext
+          items={upscalers.map((u) => u.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-2">
+            {upscalers.map((u) => (
+              <SortableUpscalerItem
+                key={u.id}
+                upscaler={u}
+                hasApiKey={!!apiKeys.replicate}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+
+      <AddCustomUpscalerButton disabled={!apiKeys.replicate} apiKey={apiKeys.replicate} />
     </div>
   );
 }

--- a/app/hooks/useUpscale.ts
+++ b/app/hooks/useUpscale.ts
@@ -3,15 +3,15 @@ import { useGalleryStore } from "~/stores/galleryStore";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { saveImage } from "~/lib/db";
 import { createThumbnailBlob } from "~/lib/imageProcessing";
-import { executeUpscale, type UpscalerOption } from "~/lib/upscaling";
-import type { CompletedGalleryItem } from "~/types";
+import { executeUpscale } from "~/lib/upscaling";
+import type { CompletedGalleryItem, StoredUpscaler } from "~/types";
 
 export type UpscaleStatus = "idle" | "running" | "done" | "error";
 
 export function useUpscale(): {
   status: UpscaleStatus;
   error: string | null;
-  upscale: (source: CompletedGalleryItem, upscaler: UpscalerOption) => Promise<void>;
+  upscale: (source: CompletedGalleryItem, upscaler: StoredUpscaler) => Promise<void>;
 } {
   const [status, setStatus] = useState<UpscaleStatus>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -21,7 +21,7 @@ export function useUpscale(): {
   const updateItem = useGalleryStore((s) => s.updateItem);
 
   const upscale = useCallback(
-    async (source: CompletedGalleryItem, upscaler: UpscalerOption) => {
+    async (source: CompletedGalleryItem, upscaler: StoredUpscaler) => {
       if (!apiKey) return;
 
       setStatus("running");
@@ -34,7 +34,7 @@ export function useUpscale(): {
           id: newId,
           status: "generating",
           modelId: source.modelId,
-          modelName: `${upscaler.label} ↑`,
+          modelName: `${upscaler.name} ↑`,
           prompt: source.prompt,
           basePrompt: source.basePrompt,
           variationReplacements: source.variationReplacements,
@@ -52,7 +52,7 @@ export function useUpscale(): {
         const metadata = {
           upscaledFrom: source.id,
           upscaler: upscaler.id,
-          upscaleLabel: upscaler.label,
+          upscaleLabel: upscaler.name,
         };
 
         await saveImage({
@@ -63,7 +63,7 @@ export function useUpscale(): {
           basePrompt: source.basePrompt,
           variationReplacements: source.variationReplacements,
           modelId: source.modelId,
-          modelName: `${upscaler.label} ↑`,
+          modelName: `${upscaler.name} ↑`,
           aspectRatio: source.aspectRatio,
           resolution: source.resolution,
           width: result.width,

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -1,4 +1,4 @@
-import type { StoredModel, StoredTextModel } from "~/types";
+import type { StoredModel, StoredTextModel, StoredUpscaler } from "~/types";
 
 const BASE_BUILT_IN_MODELS: StoredModel[] = [
   {
@@ -296,4 +296,65 @@ export function mergeWithBuiltInTextModels(models?: StoredTextModel[]): StoredTe
   }
 
   return merged;
+}
+
+export const BUILT_IN_UPSCALERS: StoredUpscaler[] = [
+  {
+    id: "real-esrgan-2x",
+    name: "Real-ESRGAN 2x",
+    replicateId: "nightmareai/real-esrgan",
+    scale: 2,
+    scaleParam: "scale",
+    enabled: true,
+  },
+  {
+    id: "real-esrgan-4x",
+    name: "Real-ESRGAN 4x",
+    replicateId: "nightmareai/real-esrgan",
+    scale: 4,
+    scaleParam: "scale",
+    enabled: true,
+  },
+  {
+    id: "aura-sr-v2",
+    name: "AuraSR 4x",
+    replicateId:
+      "zsxkib/aura-sr-v2:5c137257cce8d5ce16e8a334b70e9e025106b5580affed0bc7d48940b594e74c",
+    scale: null,
+    scaleParam: null,
+    enabled: true,
+  },
+  {
+    id: "clarity",
+    name: "Clarity",
+    replicateId:
+      "philz1337x/clarity-upscaler:dfad41707589d68ecdccd1dfa600d55a208f9310748e44bfe35b4a6291453d5e",
+    scale: null,
+    scaleParam: null,
+    enabled: true,
+  },
+];
+
+const BUILT_IN_UPSCALER_IDS = new Set(BUILT_IN_UPSCALERS.map((u) => u.id));
+
+export function isBuiltInUpscaler(id: string): boolean {
+  return BUILT_IN_UPSCALER_IDS.has(id);
+}
+
+export function mergeWithBuiltInUpscalers(upscalers?: StoredUpscaler[]): StoredUpscaler[] {
+  if (!upscalers || upscalers.length === 0) {
+    return BUILT_IN_UPSCALERS.map((u) => ({ ...u }));
+  }
+
+  const existingById = new Map(upscalers.map((u) => [u.id, u]));
+
+  const mergedBuiltIns = BUILT_IN_UPSCALERS.map((builtIn) => {
+    const existing = existingById.get(builtIn.id);
+    if (!existing) return { ...builtIn };
+    return { ...builtIn, enabled: existing.enabled };
+  });
+
+  const customUpscalers = upscalers.filter((u) => !isBuiltInUpscaler(u.id));
+
+  return [...mergedBuiltIns, ...customUpscalers];
 }

--- a/app/lib/upscaling.ts
+++ b/app/lib/upscaling.ts
@@ -2,34 +2,11 @@ import Replicate from "replicate";
 import { blobToBase64 } from "./util";
 import { getImageDimensions } from "./imageProcessing";
 import type { GenerationResult } from "./generation";
-
-export interface UpscalerOption {
-  id: string;
-  label: string;
-  scale: number | null;
-  scaleParam: string | null;
-}
-
-export const UPSCALERS: UpscalerOption[] = [
-  { id: "nightmareai/real-esrgan", label: "Real-ESRGAN 2x", scale: 2, scaleParam: "scale" },
-  { id: "nightmareai/real-esrgan", label: "Real-ESRGAN 4x", scale: 4, scaleParam: "scale" },
-  {
-    id: "zsxkib/aura-sr-v2:5c137257cce8d5ce16e8a334b70e9e025106b5580affed0bc7d48940b594e74c",
-    label: "AuraSR 4x",
-    scale: null,
-    scaleParam: null,
-  },
-  {
-    id: "philz1337x/clarity-upscaler:dfad41707589d68ecdccd1dfa600d55a208f9310748e44bfe35b4a6291453d5e",
-    label: "Clarity",
-    scale: null,
-    scaleParam: null,
-  },
-];
+import type { StoredUpscaler } from "~/types";
 
 export async function executeUpscale(
   sourceBlob: Blob,
-  upscaler: UpscalerOption,
+  upscaler: StoredUpscaler,
   apiKey: string
 ): Promise<GenerationResult> {
   const baseUrl = new URL("/proxy/replicate/v1", window.location.origin).toString();
@@ -42,12 +19,7 @@ export async function executeUpscale(
     input[upscaler.scaleParam] = upscaler.scale;
   }
 
-  let output;
-  try {
-    output = await replicate.run(upscaler.id as `${string}/${string}`, { input });
-  } catch (error) {
-    throw error;
-  }
+  const output = await replicate.run(upscaler.replicateId as `${string}/${string}`, { input });
 
   const imageUrl =
     typeof output === "object" && output !== null && "url" in output

--- a/app/stores/settingsStore.ts
+++ b/app/stores/settingsStore.ts
@@ -185,10 +185,7 @@ export const useSettingsStore = create<SettingsState>()(
             ...(icon && { icon }),
           };
           return {
-            textModels: [
-              ...state.textModels.map((m) => ({ ...m, enabled: false })),
-              newModel,
-            ],
+            textModels: [...state.textModels.map((m) => ({ ...m, enabled: false })), newModel],
           };
         }),
 
@@ -254,8 +251,7 @@ export const useSettingsStore = create<SettingsState>()(
       setEditorContextInjectionEnabled: (enabled) =>
         set({ editorContextInjectionEnabled: enabled }),
 
-      setAlwaysImprovePromptEnabled: (enabled) =>
-        set({ alwaysImprovePromptEnabled: enabled }),
+      setAlwaysImprovePromptEnabled: (enabled) => set({ alwaysImprovePromptEnabled: enabled }),
 
       incrementRequestedOutputCount: (count = 1) =>
         set((state) => ({
@@ -264,7 +260,7 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: "studio-settings",
-      version: 11,
+      version: 12,
       partialize: (state) => ({
         apiKeys: state.apiKeys,
         models: state.models,
@@ -276,7 +272,6 @@ export const useSettingsStore = create<SettingsState>()(
         editorContextInjectionEnabled: state.editorContextInjectionEnabled,
         alwaysImprovePromptEnabled: state.alwaysImprovePromptEnabled,
       }),
-      version: 12,
       migrate: (persisted, version) => {
         let state = persisted as {
           apiKeys?: ApiKeys;
@@ -290,23 +285,6 @@ export const useSettingsStore = create<SettingsState>()(
           editorContextInjectionEnabled?: boolean;
           alwaysImprovePromptEnabled?: boolean;
         };
-
-        // always update builtin models
-        state = {
-          ...state,
-          models: mergeWithBuiltInModels(state.models),
-        };
-
-        if (version < 2) {
-          // Migration from v1: add models array
-          state = {
-            apiKeys: {
-              google: state.apiKeys?.google ?? null,
-              replicate: state.apiKeys?.replicate ?? null,
-            },
-            models: BUILT_IN_MODELS,
-          };
-        }
 
         if (version < 3) {
           // Migration from v2: add icons to built-in models
@@ -330,19 +308,27 @@ export const useSettingsStore = create<SettingsState>()(
           };
         }
 
-        if (version < 5) {
-          state = {
-            ...state,
-            desktopNotificationsEnabled: false,
-            notificationPromptDismissed: false,
-            requestedOutputCount: 0,
-          };
-        }
-
         if (version < 6) {
           state = {
             ...state,
             textModel: { provider: "google", modelId: "gemini-3-flash-preview" },
+            models: state.models?.map((model) =>
+              isBuiltInModel(model.id) ? { ...model, isCustom: undefined } : model
+            ),
+            desktopNotificationsEnabled: state.desktopNotificationsEnabled ?? false,
+            notificationPromptDismissed: state.notificationPromptDismissed ?? false,
+            requestedOutputCount: state.requestedOutputCount ?? 0,
+          };
+        }
+
+        if (version < 8) {
+          state = {
+            ...state,
+            models: state.models?.map((model) =>
+              model.provider === "replicate" && model.isCustom
+                ? { ...model, schemaFetched: false }
+                : model
+            ),
           };
         }
 
@@ -372,54 +358,22 @@ export const useSettingsStore = create<SettingsState>()(
           state = { ...state, textModels: seed, textModel: undefined };
         }
 
-        // always update builtin text models
-        state = {
-          ...state,
-          textModels: mergeWithBuiltInTextModels(state.textModels),
-        };
-
-        // always update builtin upscalers
-        state = {
-          ...state,
-          upscalers: mergeWithBuiltInUpscalers(state.upscalers),
-        };
-
-        state = {
-          ...state,
-          models: state.models?.map((model) =>
-            isBuiltInModel(model.id) ? { ...model, isCustom: undefined } : model
-          ),
+        // kinda duplicating our default state here but ensures all fields are populated correctly after migration
+        return {
+          apiKeys: {
+            google: state.apiKeys?.google ?? null,
+            replicate: state.apiKeys?.replicate ?? null,
+          },
+          // always merge with built-in
+          models: mergeWithBuiltInModels(state.models) ?? BUILT_IN_MODELS,
+          textModels: mergeWithBuiltInTextModels(state.textModels) ?? BUILT_IN_TEXT_MODELS,
+          upscalers: mergeWithBuiltInUpscalers(state.upscalers) ?? BUILT_IN_UPSCALERS,
           desktopNotificationsEnabled: state.desktopNotificationsEnabled ?? false,
           notificationPromptDismissed: state.notificationPromptDismissed ?? false,
           requestedOutputCount: state.requestedOutputCount ?? 0,
+          editorContextInjectionEnabled: state.editorContextInjectionEnabled ?? true,
+          alwaysImprovePromptEnabled: state.alwaysImprovePromptEnabled ?? false,
         };
-
-        if (version < 8) {
-          state = {
-            ...state,
-            models: state.models?.map((model) =>
-              model.provider === "replicate" && model.isCustom
-                ? { ...model, schemaFetched: false }
-                : model
-            ),
-          };
-        }
-
-        if (version < 9) {
-          state = {
-            ...state,
-            editorContextInjectionEnabled: state.editorContextInjectionEnabled ?? true,
-          };
-        }
-
-        if (version < 10) {
-          state = {
-            ...state,
-            alwaysImprovePromptEnabled: state.alwaysImprovePromptEnabled ?? false,
-          };
-        }
-
-        return state;
       },
     }
   )

--- a/app/stores/settingsStore.ts
+++ b/app/stores/settingsStore.ts
@@ -3,9 +3,11 @@ import { persist } from "zustand/middleware";
 import {
   BUILT_IN_MODELS,
   BUILT_IN_TEXT_MODELS,
+  BUILT_IN_UPSCALERS,
   isBuiltInModel,
   mergeWithBuiltInModels,
   mergeWithBuiltInTextModels,
+  mergeWithBuiltInUpscalers,
 } from "~/lib/builtInModels";
 import { hasProviderAccess } from "~/lib/providers";
 import type {
@@ -16,12 +18,14 @@ import type {
   SchemaMapping,
   StoredModel,
   StoredTextModel,
+  StoredUpscaler,
 } from "~/types";
 
 interface SettingsState {
   apiKeys: ApiKeys;
   models: StoredModel[];
   textModels: StoredTextModel[];
+  upscalers: StoredUpscaler[];
   desktopNotificationsEnabled: boolean;
   notificationPromptDismissed: boolean;
   requestedOutputCount: number;
@@ -49,6 +53,12 @@ interface SettingsState {
     schemaFetched?: boolean
   ) => void;
   updateModelSchemaMapping: (id: string, schemaMapping: SchemaMapping) => void;
+
+  // Upscaler actions
+  setUpscalerEnabled: (id: string, enabled: boolean) => void;
+  addCustomUpscaler: (replicateId: string, name: string, icon?: string) => void;
+  removeCustomUpscaler: (id: string) => void;
+  reorderUpscalers: (activeId: string, overId: string) => void;
 
   // Text model actions
   selectTextModel: (id: string) => void;
@@ -81,6 +91,7 @@ export const useSettingsStore = create<SettingsState>()(
       },
       models: BUILT_IN_MODELS,
       textModels: BUILT_IN_TEXT_MODELS,
+      upscalers: BUILT_IN_UPSCALERS,
       desktopNotificationsEnabled: false,
       notificationPromptDismissed: false,
       requestedOutputCount: 0,
@@ -192,6 +203,50 @@ export const useSettingsStore = create<SettingsState>()(
           return { textModels: remaining };
         }),
 
+      setUpscalerEnabled: (id, enabled) =>
+        set((state) => ({
+          upscalers: state.upscalers.map((u) => (u.id === id ? { ...u, enabled } : u)),
+        })),
+
+      addCustomUpscaler: (replicateId, name, icon) =>
+        set((state) => {
+          const id = `replicate/${replicateId}`;
+          if (state.upscalers.some((u) => u.id === id)) return state;
+          return {
+            upscalers: [
+              ...state.upscalers,
+              {
+                id,
+                name,
+                replicateId,
+                scale: null,
+                scaleParam: null,
+                enabled: true,
+                isCustom: true,
+                ...(icon && { icon }),
+              },
+            ],
+          };
+        }),
+
+      removeCustomUpscaler: (id) =>
+        set((state) => ({
+          upscalers: state.upscalers.some((u) => u.id === id && u.isCustom)
+            ? state.upscalers.filter((u) => u.id !== id)
+            : state.upscalers,
+        })),
+
+      reorderUpscalers: (activeId, overId) =>
+        set((state) => {
+          const oldIndex = state.upscalers.findIndex((u) => u.id === activeId);
+          const newIndex = state.upscalers.findIndex((u) => u.id === overId);
+          if (oldIndex === -1 || newIndex === -1) return state;
+          const newUpscalers = [...state.upscalers];
+          const [moved] = newUpscalers.splice(oldIndex, 1);
+          newUpscalers.splice(newIndex, 0, moved);
+          return { upscalers: newUpscalers };
+        }),
+
       setDesktopNotificationsEnabled: (enabled) => set({ desktopNotificationsEnabled: enabled }),
 
       dismissNotificationPrompt: () => set({ notificationPromptDismissed: true }),
@@ -214,18 +269,21 @@ export const useSettingsStore = create<SettingsState>()(
         apiKeys: state.apiKeys,
         models: state.models,
         textModels: state.textModels,
+        upscalers: state.upscalers,
         desktopNotificationsEnabled: state.desktopNotificationsEnabled,
         notificationPromptDismissed: state.notificationPromptDismissed,
         requestedOutputCount: state.requestedOutputCount,
         editorContextInjectionEnabled: state.editorContextInjectionEnabled,
         alwaysImprovePromptEnabled: state.alwaysImprovePromptEnabled,
       }),
+      version: 12,
       migrate: (persisted, version) => {
         let state = persisted as {
           apiKeys?: ApiKeys;
           models?: StoredModel[];
           textModel?: { provider: ApiKeyProvider; modelId: string };
           textModels?: StoredTextModel[];
+          upscalers?: StoredUpscaler[];
           desktopNotificationsEnabled?: boolean;
           notificationPromptDismissed?: boolean;
           requestedOutputCount?: number;
@@ -320,6 +378,12 @@ export const useSettingsStore = create<SettingsState>()(
           textModels: mergeWithBuiltInTextModels(state.textModels),
         };
 
+        // always update builtin upscalers
+        state = {
+          ...state,
+          upscalers: mergeWithBuiltInUpscalers(state.upscalers),
+        };
+
         state = {
           ...state,
           models: state.models?.map((model) =>
@@ -364,4 +428,9 @@ export const useSettingsStore = create<SettingsState>()(
 // Helper to get enabled models that have API keys
 export function getEnabledModels(state: SettingsState): StoredModel[] {
   return state.models.filter((m) => m.enabled && hasProviderAccess(state.apiKeys, m.provider));
+}
+
+// Helper to get enabled upscalers (requires Replicate key)
+export function getEnabledUpscalers(state: SettingsState): StoredUpscaler[] {
+  return state.upscalers.filter((u) => u.enabled && hasProviderAccess(state.apiKeys, "replicate"));
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -151,6 +151,18 @@ export interface AttachSelectedItemsResult {
   reason?: string;
 }
 
+// Upscaler types
+export interface StoredUpscaler {
+  id: string; // synthetic unique id, e.g. "real-esrgan-2x" or "replicate/owner/model"
+  name: string; // "Real-ESRGAN 2x"
+  replicateId: string; // "nightmareai/real-esrgan" or "owner/model:versionHash"
+  scale: number | null;
+  scaleParam: string | null;
+  enabled: boolean;
+  isCustom?: boolean;
+  icon?: string;
+}
+
 // Text model types
 export interface StoredTextModel {
   id: string; // stable unique id, e.g. "google:gemini-3-flash-preview" or "replicate:google/gemini-3-flash"


### PR DESCRIPTION
## Summary
This PR adds a complete upscaler management system to the settings sidebar, allowing users to enable/disable upscalers, reorder them, and add custom Replicate models as upscalers.

## Key Changes

- **New Upscaler State Management**: Added `upscalers` array to settings store with actions for enabling/disabling, adding custom upscalers, removing them, and reordering via drag-and-drop
- **Built-in Upscalers**: Defined 4 built-in upscalers (Real-ESRGAN 2x/4x, AuraSR, Clarity) with proper merging logic to preserve user preferences across updates
- **UI Components**:
  - `AddCustomUpscalerButton`: Searchable combobox for adding custom Replicate models with real-time search suggestions
  - `UpscalerItem`: Displays individual upscaler with enable/disable toggle, drag handle, and delete button for custom upscalers
  - `SortableUpscalerItem`: Wrapper for drag-and-drop reordering
- **Settings Sidebar Integration**: Added upscaler section with drag-and-drop reordering and add button
- **Lightbox Integration**: Updated upscale picker to use enabled upscalers from settings instead of hardcoded list
- **Type System**: Added `StoredUpscaler` type with fields for ID, name, Replicate ID, scale parameters, enabled state, and optional custom/icon flags
- **Migration**: Added version 12 migration to merge built-in upscalers with persisted custom ones

## Implementation Details

- Upscaler IDs use synthetic format: `"real-esrgan-2x"` for built-ins, `"replicate/owner/model"` for custom
- Custom upscalers require Replicate API key; UI is disabled/dimmed without it
- Search suggestions are fetched from Replicate API with 300ms debounce
- Upscalers can only be enabled if user has Replicate API key configured
- Built-in upscalers are always merged with custom ones on store initialization

close #32 

https://claude.ai/code/session_01FrVYdWWEah75waziMw8vdC