### PR TITLE
Add batch image generation and quality preset support

### DIFF
--- a/app/components/editor/EditorInputBar.tsx
+++ b/app/components/editor/EditorInputBar.tsx
@@ -120,6 +120,8 @@ export function EditorInputBar({ onSourceFile }: EditorInputBarProps) {
   const modelSelections = useGenerationStore((s) => s.currentModelSelections);
   const aspectRatio = useGenerationStore((s) => s.currentAspectRatio);
   const resolution = useGenerationStore((s) => s.currentResolution);
+  const quality = useGenerationStore((s) => s.currentQuality);
+  const numberOfImages = useGenerationStore((s) => s.currentNumberOfImages);
   const models = useSettingsStore((s) => s.models);
 
   const sourcePrompt = useEditorStore((s) => s.sourcePrompt);
@@ -394,6 +396,8 @@ export function EditorInputBar({ onSourceFile }: EditorInputBarProps) {
         modelSelections,
         aspectRatio,
         resolution,
+        quality,
+        numberOfImages,
         onItemsCreated: (itemIds) => {
           for (const id of itemIds) {
             addItemToTurn(turnId, id);
@@ -425,6 +429,8 @@ export function EditorInputBar({ onSourceFile }: EditorInputBarProps) {
     modelSelections,
     aspectRatio,
     resolution,
+    quality,
+    numberOfImages,
     contextInjectionEnabled,
     contextBriefDismissed,
     turns,

--- a/app/components/lightbox/Lightbox.tsx
+++ b/app/components/lightbox/Lightbox.tsx
@@ -8,10 +8,10 @@ import {
   Trash2,
   Copy,
   FilePenLine,
-  Expand,
   RotateCcw,
   Check,
   CopyPlus,
+  ImageUpscale,
 } from "lucide-react";
 import { useLocation, useNavigate } from "react-router";
 import { useGalleryStore } from "~/stores/galleryStore";
@@ -295,7 +295,7 @@ export function Lightbox() {
                   />
                 )}
                 <WideIconButton
-                  icon={<Expand className="h-4 w-4" />}
+                  icon={<ImageUpscale className="h-4 w-4" />}
                   title={"Upscale"}
                   tooltip={
                     !replicateKey ? "Upscaling requires a Replicate API key" : "Upscale this image"

--- a/app/components/settings/ModelToggle.tsx
+++ b/app/components/settings/ModelToggle.tsx
@@ -6,6 +6,8 @@ import {
   Image,
   Box,
   RefreshCw,
+  GalleryHorizontalEnd,
+  Sparkles,
 } from "lucide-react";
 import { useSettingsStore } from "~/stores/settingsStore";
 import SVG from "react-inlinesvg";
@@ -153,9 +155,19 @@ export default function ModelToggleItem({
             enabled={capabilities.supportsResolution}
           />
           <CapabilityBadge
+            icon={Sparkles}
+            label="Quality"
+            enabled={Boolean(capabilities.supportsQuality)}
+          />
+          <CapabilityBadge
             icon={Image}
             label={`Reference images (max ${capabilities.maxReferenceImages})`}
             enabled={capabilities.supportsReferenceImages}
+          />
+          <CapabilityBadge
+            icon={GalleryHorizontalEnd}
+            label={`Batch generation (max ${capabilities.maxImagesPerRequest})`}
+            enabled={Boolean(capabilities.supportsNumberOfImages)}
           />
         </div>
       </div>

--- a/app/components/sidebar/ModelItem.tsx
+++ b/app/components/sidebar/ModelItem.tsx
@@ -4,7 +4,14 @@ import NumberFlow from "@number-flow/react";
 import type { StoredModel } from "~/types";
 import { useGenerationStore } from "~/stores/generationStore";
 import { useSettingsStore } from "~/stores/settingsStore";
-import { anyModelSupportsReferenceImages, getAspectRatioIntersection } from "~/lib/models";
+import {
+  anyModelSupportsNumberOfImages,
+  anyModelSupportsQuality,
+  anyModelSupportsReferenceImages,
+  getAspectRatioIntersection,
+  getMaxImagesPerRequest,
+  getQualityIntersection,
+} from "~/lib/models";
 
 interface ModelItemProps {
   model: StoredModel;
@@ -39,6 +46,23 @@ export function ModelItem({ model, count }: ModelItemProps) {
       !getAspectRatioIntersection(models, selectedIds).includes(generationState.currentAspectRatio)
     ) {
       generationState.setAspectRatio(null);
+    }
+
+    if (
+      generationState.currentQuality &&
+      (!anyModelSupportsQuality(models, selectedIds) ||
+        !getQualityIntersection(models, selectedIds).includes(generationState.currentQuality))
+    ) {
+      generationState.setQuality(null);
+    }
+
+    if (anyModelSupportsNumberOfImages(models, selectedIds)) {
+      const maxBatch = getMaxImagesPerRequest(models, selectedIds);
+      if (generationState.currentNumberOfImages > maxBatch) {
+        generationState.setNumberOfImages(maxBatch);
+      }
+    } else if (generationState.currentNumberOfImages > 1) {
+      generationState.setNumberOfImages(1);
     }
   };
 

--- a/app/components/sidebar/NumberOfImagesSection.tsx
+++ b/app/components/sidebar/NumberOfImagesSection.tsx
@@ -41,7 +41,11 @@ export function NumberOfImagesSection() {
         step={1}
         value={Math.min(numberOfImages, Math.max(1, max))}
         onChange={(e) => setNumberOfImages(Number(e.target.value))}
-        className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-zinc-800 accent-purple-500"
+        className="h-1.5 w-full cursor-pointer appearance-none rounded-full"
+        style={{
+          background: `linear-gradient(to right, var(--color-purple-500) 0%, var(--color-purple-500) ${((numberOfImages - 1) / (max - 1)) * 100}%, var(--color-zinc-800) ${((numberOfImages - 1) / (max - 1)) * 100}%, var(--color-zinc-800) 100%)
+          `,
+        }}
       />
       <div className="mt-1 flex justify-between text-[10px] text-zinc-500 tabular-nums">
         <span>1</span>

--- a/app/components/sidebar/NumberOfImagesSection.tsx
+++ b/app/components/sidebar/NumberOfImagesSection.tsx
@@ -22,6 +22,7 @@ export function NumberOfImagesSection() {
     if (numberOfImages > max) setNumberOfImages(max);
   }, [max, numberOfImages, setNumberOfImages]);
 
+  if (!enabled || max <= 1) return null;
   return (
     <section>
       <div className="mb-2 flex items-center gap-2">
@@ -29,7 +30,7 @@ export function NumberOfImagesSection() {
           <Images className="h-4 w-4" />
         </span>
         <h2 className="text-xs font-medium tracking-wide text-zinc-400 uppercase">Images / call</h2>
-        <span className="ml-auto text-xs font-medium tabular-nums text-zinc-300">
+        <span className="ml-auto text-xs font-medium text-zinc-300 tabular-nums">
           {numberOfImages}
         </span>
       </div>
@@ -40,10 +41,7 @@ export function NumberOfImagesSection() {
         step={1}
         value={Math.min(numberOfImages, Math.max(1, max))}
         onChange={(e) => setNumberOfImages(Number(e.target.value))}
-        disabled={!enabled || max <= 1}
-        className={`h-1.5 w-full cursor-pointer appearance-none rounded-full bg-zinc-800 accent-purple-500 ${
-          !enabled || max <= 1 ? "cursor-not-allowed opacity-40" : ""
-        }`}
+        className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-zinc-800 accent-purple-500"
       />
       <div className="mt-1 flex justify-between text-[10px] text-zinc-500 tabular-nums">
         <span>1</span>

--- a/app/components/sidebar/NumberOfImagesSection.tsx
+++ b/app/components/sidebar/NumberOfImagesSection.tsx
@@ -1,0 +1,54 @@
+import { Images } from "lucide-react";
+import { useEffect } from "react";
+import { anyModelSupportsNumberOfImages, getMaxImagesPerRequest } from "~/lib/models";
+import { useGenerationStore } from "~/stores/generationStore";
+import { useSettingsStore } from "~/stores/settingsStore";
+
+export function NumberOfImagesSection() {
+  const numberOfImages = useGenerationStore((s) => s.currentNumberOfImages);
+  const setNumberOfImages = useGenerationStore((s) => s.setNumberOfImages);
+  const modelSelections = useGenerationStore((s) => s.currentModelSelections);
+  const models = useSettingsStore((s) => s.models);
+
+  const selectedModels = Object.entries(modelSelections)
+    .filter(([, count]) => count > 0)
+    .map(([modelId]) => modelId);
+
+  const enabled = anyModelSupportsNumberOfImages(models, selectedModels);
+  const max = enabled ? getMaxImagesPerRequest(models, selectedModels) : 1;
+
+  // Clamp to the current max when the selection changes.
+  useEffect(() => {
+    if (numberOfImages > max) setNumberOfImages(max);
+  }, [max, numberOfImages, setNumberOfImages]);
+
+  return (
+    <section>
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-zinc-500">
+          <Images className="h-4 w-4" />
+        </span>
+        <h2 className="text-xs font-medium tracking-wide text-zinc-400 uppercase">Images / call</h2>
+        <span className="ml-auto text-xs font-medium tabular-nums text-zinc-300">
+          {numberOfImages}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={1}
+        max={Math.max(1, max)}
+        step={1}
+        value={Math.min(numberOfImages, Math.max(1, max))}
+        onChange={(e) => setNumberOfImages(Number(e.target.value))}
+        disabled={!enabled || max <= 1}
+        className={`h-1.5 w-full cursor-pointer appearance-none rounded-full bg-zinc-800 accent-purple-500 ${
+          !enabled || max <= 1 ? "cursor-not-allowed opacity-40" : ""
+        }`}
+      />
+      <div className="mt-1 flex justify-between text-[10px] text-zinc-500 tabular-nums">
+        <span>1</span>
+        <span>{Math.max(1, max)}</span>
+      </div>
+    </section>
+  );
+}

--- a/app/components/sidebar/QualitySection.tsx
+++ b/app/components/sidebar/QualitySection.tsx
@@ -27,6 +27,7 @@ export function QualitySection() {
     [models, selectedModels]
   );
 
+  if (!pickerEnabled) return null;
   return (
     <section>
       <div className="mb-2 flex items-center gap-2">
@@ -45,7 +46,6 @@ export function QualitySection() {
             <button
               key={q}
               onClick={() => isEnabled && setQuality(isSelected ? null : q)}
-              disabled={!isEnabled}
               className={`flex-1 rounded-lg px-2 py-2 text-xs font-medium transition-colors ${
                 showSelectedStyle
                   ? "border border-purple-500 bg-purple-500/20 text-purple-300"

--- a/app/components/sidebar/QualitySection.tsx
+++ b/app/components/sidebar/QualitySection.tsx
@@ -1,0 +1,64 @@
+import { Sparkles } from "lucide-react";
+import { useMemo } from "react";
+import { QUALITIES, anyModelSupportsQuality, getQualityIntersection } from "~/lib/models";
+import { useGenerationStore } from "~/stores/generationStore";
+import { useSettingsStore } from "~/stores/settingsStore";
+
+const QUALITY_LABELS: Record<string, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  auto: "Auto",
+};
+
+export function QualitySection() {
+  const quality = useGenerationStore((s) => s.currentQuality);
+  const setQuality = useGenerationStore((s) => s.setQuality);
+  const modelSelections = useGenerationStore((s) => s.currentModelSelections);
+  const models = useSettingsStore((s) => s.models);
+
+  const selectedModels = Object.entries(modelSelections)
+    .filter(([, count]) => count > 0)
+    .map(([modelId]) => modelId);
+
+  const pickerEnabled = anyModelSupportsQuality(models, selectedModels);
+  const selectable = useMemo(
+    () => new Set(getQualityIntersection(models, selectedModels)),
+    [models, selectedModels]
+  );
+
+  return (
+    <section>
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-zinc-500">
+          <Sparkles className="h-4 w-4" />
+        </span>
+        <h2 className="text-xs font-medium tracking-wide text-zinc-400 uppercase">Quality</h2>
+      </div>
+      <div className="flex gap-2">
+        {QUALITIES.map((q) => {
+          const isSelected = quality === q;
+          const isEnabled = pickerEnabled && (selectable.size === 0 || selectable.has(q));
+          const showSelectedStyle = isSelected && isEnabled;
+
+          return (
+            <button
+              key={q}
+              onClick={() => isEnabled && setQuality(isSelected ? null : q)}
+              disabled={!isEnabled}
+              className={`flex-1 rounded-lg px-2 py-2 text-xs font-medium transition-colors ${
+                showSelectedStyle
+                  ? "border border-purple-500 bg-purple-500/20 text-purple-300"
+                  : isEnabled
+                    ? "border border-zinc-700 bg-zinc-800 text-zinc-400 hover:border-zinc-600"
+                    : "cursor-not-allowed border border-zinc-800 bg-zinc-800/50 text-zinc-500 opacity-40"
+              }`}
+            >
+              {QUALITY_LABELS[q] ?? q}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -4,6 +4,8 @@ import { PromptInput } from "./PromptInput";
 import { ModelList } from "./ModelList";
 import { AspectRatioSection } from "./AspectRatioSection";
 import { ResolutionSection } from "./ResolutionSection";
+import { QualitySection } from "./QualitySection";
+import { NumberOfImagesSection } from "./NumberOfImagesSection";
 import { GenerateButton } from "./GenerateButton";
 import { PromptVariationsToggle } from "./PromptVariationsToggle";
 import { AvoidPastVariationsToggle } from "./AvoidPastVariationsToggle";
@@ -58,6 +60,8 @@ function GallerySidebarContent() {
         <ModelList />
         <AspectRatioSection />
         <ResolutionSection />
+        <QualitySection />
+        <NumberOfImagesSection />
       </div>
       <div className="border-t border-zinc-800 p-4">
         <GenerateButton />
@@ -73,6 +77,8 @@ function EditorSidebarContent() {
       <ModelList />
       <AspectRatioSection />
       <ResolutionSection />
+      <QualitySection />
+      <NumberOfImagesSection />
     </div>
   );
 }

--- a/app/hooks/useEditorGeneration.ts
+++ b/app/hooks/useEditorGeneration.ts
@@ -41,6 +41,8 @@ export function useEditorGeneration() {
       modelSelections: Record<string, number>;
       aspectRatio: AspectRatio | null;
       resolution: Resolution;
+      quality: string | null;
+      numberOfImages: number;
       onItemsCreated: (itemIds: string[]) => void;
       onPromptPrepared?: (prompt: string) => void;
     }): Promise<void> => {
@@ -54,6 +56,8 @@ export function useEditorGeneration() {
         modelSelections,
         aspectRatio,
         resolution,
+        quality,
+        numberOfImages,
         onItemsCreated,
         onPromptPrepared,
       } = params;
@@ -70,12 +74,14 @@ export function useEditorGeneration() {
       const allReferenceIds = allReferences.map((r) => r.id);
 
       const taskSlots: Array<{
-        id: string;
+        itemIds: string[];
         modelId: string;
         modelName: string;
         provider: GenerationTask["provider"];
         aspectRatio: GenerationTask["aspectRatio"];
         resolution: GenerationTask["resolution"];
+        quality: string | null;
+        numberOfImages: number;
       }> = [];
       const pendingItems: GalleryItem[] = [];
 
@@ -84,45 +90,56 @@ export function useEditorGeneration() {
         const model = getModel(models, modelId);
         if (!model) continue;
 
+        const taskResolution = model.capabilities.supportsResolution ? resolution : null;
+        const supportedRatios = model.capabilities.supportedAspectRatios;
+        const taskAspectRatio =
+          aspectRatio && supportedRatios
+            ? supportedRatios.includes(aspectRatio)
+              ? aspectRatio
+              : null
+            : model.capabilities.supportsAspectRatios
+              ? aspectRatio
+              : null;
+        const taskQuality = model.capabilities.supportsQuality ? quality : null;
+        const maxBatch = model.capabilities.maxImagesPerRequest ?? 1;
+        const perCallImages = model.capabilities.supportsNumberOfImages
+          ? Math.max(1, Math.min(numberOfImages, maxBatch))
+          : 1;
+
         for (let i = 0; i < count; i++) {
-          const taskId = crypto.randomUUID();
-          const taskResolution = model.capabilities.supportsResolution ? resolution : null;
-          const supportedRatios = model.capabilities.supportedAspectRatios;
-          const taskAspectRatio =
-            aspectRatio && supportedRatios
-              ? supportedRatios.includes(aspectRatio)
-                ? aspectRatio
-                : null
-              : model.capabilities.supportsAspectRatios
-                ? aspectRatio
-                : null;
+          const itemIds = Array.from({ length: perCallImages }, () => crypto.randomUUID());
 
           taskSlots.push({
-            id: taskId,
+            itemIds,
             modelId,
             modelName: model.name,
             provider: model.provider,
             aspectRatio: taskAspectRatio,
             resolution: taskResolution,
+            quality: taskQuality,
+            numberOfImages: perCallImages,
           });
 
-          pendingItems.push({
-            id: taskId,
-            status: "pending",
-            modelId,
-            modelName: model.name,
-            prompt: instruction,
-            basePrompt,
-            aspectRatio: taskAspectRatio,
-            resolution: taskResolution,
-            referenceImageIds: allReferenceIds,
-            retryCount: 0,
-          });
+          for (const itemId of itemIds) {
+            pendingItems.push({
+              id: itemId,
+              status: "pending",
+              modelId,
+              modelName: model.name,
+              prompt: instruction,
+              basePrompt,
+              aspectRatio: taskAspectRatio,
+              resolution: taskResolution,
+              quality: taskQuality,
+              referenceImageIds: allReferenceIds,
+              retryCount: 0,
+            });
+          }
         }
       }
 
       if (taskSlots.length === 0) return;
-      const taskIds = taskSlots.map((slot) => slot.id);
+      const taskIds = taskSlots.flatMap((slot) => slot.itemIds);
 
       addItems(pendingItems);
       onItemsCreated(taskIds);
@@ -155,7 +172,7 @@ export function useEditorGeneration() {
       const displayBasePrompt = basePrompt && sentPrompt !== basePrompt ? basePrompt : undefined;
 
       const tasks: GenerationTask[] = taskSlots.map((slot, taskIndex) => ({
-        id: slot.id,
+        itemIds: slot.itemIds,
         modelId: slot.modelId,
         modelName: slot.modelName,
         provider: slot.provider,
@@ -163,15 +180,19 @@ export function useEditorGeneration() {
         basePrompt: displayBasePrompt,
         aspectRatio: slot.aspectRatio,
         resolution: slot.resolution,
+        quality: slot.quality,
+        numberOfImages: slot.numberOfImages,
         referenceImages: allReferences,
       }));
 
       updatePendingPromptFields(
-        tasks.map((task) => ({
-          id: task.id,
-          prompt: task.prompt,
-          basePrompt: task.basePrompt,
-        }))
+        tasks.flatMap((task) =>
+          task.itemIds.map((id) => ({
+            id,
+            prompt: task.prompt,
+            basePrompt: task.basePrompt,
+          }))
+        )
       );
       updatePendingPhase(taskIds, undefined);
 

--- a/app/hooks/useGenerationTask.ts
+++ b/app/hooks/useGenerationTask.ts
@@ -10,7 +10,9 @@ import { useSettingsStore } from "~/stores/settingsStore";
 import type { AspectRatio, Provider, Resolution } from "~/types";
 
 export interface GenerationTask {
-  id: string;
+  /** Gallery item IDs this task produces. Length 1 for single-image models,
+   *  greater for batch-capable models called with numberOfImages > 1. */
+  itemIds: string[];
   modelId: string;
   modelName: string;
   provider: Provider;
@@ -19,6 +21,8 @@ export interface GenerationTask {
   variationReplacements?: string[];
   aspectRatio: AspectRatio | null;
   resolution: Resolution | null;
+  quality: string | null;
+  numberOfImages: number;
   referenceImages: Array<{ id: string; blob: Blob; sourceGalleryItemId?: string }>;
 }
 
@@ -34,8 +38,15 @@ export function useGenerationTask() {
   const updateItem = useGalleryStore((s) => s.updateItem);
   const getItem = useGalleryStore((s) => s.getItem);
 
+  const updateAll = useCallback(
+    (ids: string[], patch: Parameters<typeof updateItem>[1]) => {
+      for (const id of ids) updateItem(id, patch);
+    },
+    [updateItem]
+  );
+
   const executeTask = useCallback(
-    async (task: GenerationTask): Promise<GenerationResult> => {
+    async (task: GenerationTask): Promise<GenerationResult[]> => {
       const apiKey = providerRequiresApiKey(task.provider) ? apiKeys[task.provider] : undefined;
       if (providerRequiresApiKey(task.provider) && !apiKey) {
         throw new Error(`No API key for ${task.provider}`);
@@ -48,6 +59,8 @@ export function useGenerationTask() {
           prompt: task.prompt,
           aspectRatio: task.aspectRatio,
           resolution: task.resolution,
+          quality: task.quality,
+          numberOfImages: task.numberOfImages,
           referenceImages: task.referenceImages,
         },
         apiKey || undefined
@@ -60,7 +73,7 @@ export function useGenerationTask() {
     (task: GenerationTask) =>
       retryWithBackoff(() => executeTask(task), {
         onWaiting: ({ retryCount, waitMs, waitingUntil }) => {
-          updateItem(task.id, {
+          updateAll(task.itemIds, {
             status: "waiting",
             retryCount,
             waitingUntil,
@@ -68,56 +81,73 @@ export function useGenerationTask() {
           });
         },
         onRetrying: ({ retryCount }) => {
-          updateItem(task.id, { status: "generating", retryCount });
+          updateAll(task.itemIds, { status: "generating", retryCount });
         },
       }),
-    [executeTask, updateItem]
+    [executeTask, updateAll]
   );
 
   const completeTask = useCallback(
-    async (task: GenerationTask, result: GenerationResult, generationTimeMs: number) => {
-      const thumbnailBlob = await createThumbnailBlob(result.blob, 400);
-      const createdAt = Date.now();
-
+    async (task: GenerationTask, results: GenerationResult[], generationTimeMs: number) => {
       const parentGalleryItemIds = task.referenceImages
         .map((r) => r.sourceGalleryItemId)
         .filter((id): id is string => !!id);
 
-      await saveImage({
-        id: task.id,
-        originalBlob: result.blob,
-        thumbnailBlob,
-        prompt: task.prompt,
-        basePrompt: task.basePrompt,
-        variationReplacements: task.variationReplacements,
-        modelId: task.modelId,
-        modelName: task.modelName,
-        aspectRatio: task.aspectRatio,
-        resolution: task.resolution,
-        width: result.width,
-        height: result.height,
-        createdAt,
-        generationTimeMs,
-        referenceImageIds: task.referenceImages.map((referenceImage) => referenceImage.id),
-        parentGalleryItemIds: parentGalleryItemIds.length > 0 ? parentGalleryItemIds : undefined,
-        metadata: result.metadata,
-      });
+      const createdAt = Date.now();
 
-      updateItem(task.id, {
-        status: "completed",
-        originalBlob: result.blob,
-        originalUrl: URL.createObjectURL(result.blob),
-        thumbnailBlob,
-        thumbnailUrl: URL.createObjectURL(thumbnailBlob),
-        width: result.width,
-        height: result.height,
-        createdAt,
-        generationTimeMs,
-        metadata: result.metadata,
-        parentGalleryItemIds: parentGalleryItemIds.length > 0 ? parentGalleryItemIds : undefined,
-      });
+      // Pair each expected itemId with a result; fail the extras if fewer results arrived.
+      await Promise.all(
+        task.itemIds.map(async (itemId, index) => {
+          const result = results[index];
+          if (!result) {
+            updateItem(itemId, {
+              status: "failed",
+              error: "Model returned fewer images than requested",
+              canRetry: true,
+            });
+            return;
+          }
 
-      return result;
+          const thumbnailBlob = await createThumbnailBlob(result.blob, 400);
+
+          await saveImage({
+            id: itemId,
+            originalBlob: result.blob,
+            thumbnailBlob,
+            prompt: task.prompt,
+            basePrompt: task.basePrompt,
+            variationReplacements: task.variationReplacements,
+            modelId: task.modelId,
+            modelName: task.modelName,
+            aspectRatio: task.aspectRatio,
+            resolution: task.resolution,
+            quality: task.quality,
+            width: result.width,
+            height: result.height,
+            createdAt,
+            generationTimeMs,
+            referenceImageIds: task.referenceImages.map((r) => r.id),
+            parentGalleryItemIds: parentGalleryItemIds.length > 0 ? parentGalleryItemIds : undefined,
+            metadata: result.metadata,
+          });
+
+          updateItem(itemId, {
+            status: "completed",
+            originalBlob: result.blob,
+            originalUrl: URL.createObjectURL(result.blob),
+            thumbnailBlob,
+            thumbnailUrl: URL.createObjectURL(thumbnailBlob),
+            width: result.width,
+            height: result.height,
+            createdAt,
+            generationTimeMs,
+            metadata: result.metadata,
+            parentGalleryItemIds: parentGalleryItemIds.length > 0 ? parentGalleryItemIds : undefined,
+          });
+        })
+      );
+
+      return results;
     },
     [updateItem]
   );
@@ -125,15 +155,15 @@ export function useGenerationTask() {
   const runTask = useCallback(
     async (task: GenerationTask, options: RunTaskOptions = {}) => {
       const { useRetry = true, getCanRetry = () => true } = options;
-      updateItem(task.id, { status: "generating" });
+      updateAll(task.itemIds, { status: "generating" });
 
       try {
         const startTime = Date.now();
-        const result = useRetry ? await executeWithRetry(task) : await executeTask(task);
-        return await completeTask(task, result, Date.now() - startTime);
+        const results = useRetry ? await executeWithRetry(task) : await executeTask(task);
+        return await completeTask(task, results, Date.now() - startTime);
       } catch (error) {
         const message = error instanceof Error ? error.message : "Generation failed";
-        updateItem(task.id, {
+        updateAll(task.itemIds, {
           status: "failed",
           error: message,
           canRetry: getCanRetry(error, task),
@@ -141,17 +171,18 @@ export function useGenerationTask() {
         throw error;
       }
     },
-    [completeTask, executeTask, executeWithRetry, updateItem]
+    [completeTask, executeTask, executeWithRetry, updateAll]
   );
 
   const runTasks = useCallback(
     async (
       tasks: GenerationTask[],
       options: RunTaskOptions = {}
-    ): Promise<PromiseSettledResult<GenerationResult>[]> => {
+    ): Promise<PromiseSettledResult<GenerationResult[]>[]> => {
       if (tasks.length === 0) return [];
 
-      incrementRequestedOutputCount(tasks.length);
+      const totalItems = tasks.reduce((sum, t) => sum + t.itemIds.length, 0);
+      incrementRequestedOutputCount(totalItems);
 
       return Promise.allSettled(
         tasks.map((task) =>
@@ -175,7 +206,7 @@ export function useGenerationTask() {
 
       const persistedReferences = await getReferenceImagesByIds(item.referenceImageIds);
       const task: GenerationTask = {
-        id: itemId,
+        itemIds: [itemId],
         modelId: item.modelId,
         modelName: item.modelName,
         provider: model.provider,
@@ -184,6 +215,8 @@ export function useGenerationTask() {
         variationReplacements: item.variationReplacements,
         aspectRatio: item.aspectRatio,
         resolution: item.resolution,
+        quality: item.quality ?? null,
+        numberOfImages: 1,
         referenceImages: persistedReferences.map((referenceImage) => ({
           id: referenceImage.id,
           blob: referenceImage.blob,

--- a/app/hooks/useImageGeneration.ts
+++ b/app/hooks/useImageGeneration.ts
@@ -16,6 +16,8 @@ export function useImageGeneration() {
   const modelSelections = useGenerationStore((s) => s.currentModelSelections);
   const aspectRatio = useGenerationStore((s) => s.currentAspectRatio);
   const resolution = useGenerationStore((s) => s.currentResolution);
+  const quality = useGenerationStore((s) => s.currentQuality);
+  const numberOfImages = useGenerationStore((s) => s.currentNumberOfImages);
   const referenceImages = useGenerationStore((s) => s.currentReferenceImages);
   const startGeneration = useGenerationStore((s) => s.startGeneration);
   const finishGeneration = useGenerationStore((s) => s.finishGeneration);
@@ -47,10 +49,13 @@ export function useImageGeneration() {
       modelSelections,
       aspectRatio,
       resolution,
+      quality,
+      numberOfImages,
       referenceImages,
     });
 
-    // Count total tasks synchronously (everything except final prompt text is known upfront)
+    // Count total API calls synchronously. One task = one API call, but a single
+    // batch-capable task may produce multiple gallery items.
     let totalTasks = 0;
     for (const [modelId, count] of Object.entries(modelSelections)) {
       if (count === 0) continue;
@@ -63,12 +68,14 @@ export function useImageGeneration() {
     // Final prompts will be patched in once the improve/variation pipeline completes.
     const originalPrompt = prompt;
     const taskSlots: Array<{
-      id: string;
+      itemIds: string[];
       modelId: string;
       modelName: string;
       provider: GenerationTask["provider"];
       aspectRatio: GenerationTask["aspectRatio"];
       resolution: GenerationTask["resolution"];
+      quality: string | null;
+      numberOfImages: number;
     }> = [];
     const pendingItems: GalleryItem[] = [];
 
@@ -77,44 +84,55 @@ export function useImageGeneration() {
       const model = getModel(models, modelId);
       if (!model) continue;
 
+      const taskResolution = model.capabilities.supportsResolution ? resolution : null;
+      const supportedRatios = model.capabilities.supportedAspectRatios;
+      const taskAspectRatio =
+        aspectRatio && supportedRatios
+          ? supportedRatios.includes(aspectRatio)
+            ? aspectRatio
+            : null
+          : model.capabilities.supportsAspectRatios
+            ? aspectRatio
+            : null;
+      const taskQuality = model.capabilities.supportsQuality ? quality : null;
+      const maxBatch = model.capabilities.maxImagesPerRequest ?? 1;
+      const perCallImages = model.capabilities.supportsNumberOfImages
+        ? Math.max(1, Math.min(numberOfImages, maxBatch))
+        : 1;
+
       for (let i = 0; i < count; i++) {
-        const taskId = crypto.randomUUID();
-        const taskResolution = model.capabilities.supportsResolution ? resolution : null;
-        const supportedRatios = model.capabilities.supportedAspectRatios;
-        const taskAspectRatio =
-          aspectRatio && supportedRatios
-            ? supportedRatios.includes(aspectRatio)
-              ? aspectRatio
-              : null
-            : model.capabilities.supportsAspectRatios
-              ? aspectRatio
-              : null;
+        const itemIds = Array.from({ length: perCallImages }, () => crypto.randomUUID());
 
         taskSlots.push({
-          id: taskId,
+          itemIds,
           modelId,
           modelName: model.name,
           provider: model.provider,
           aspectRatio: taskAspectRatio,
           resolution: taskResolution,
+          quality: taskQuality,
+          numberOfImages: perCallImages,
         });
 
-        pendingItems.push({
-          id: taskId,
-          status: "pending",
-          modelId,
-          modelName: model.name,
-          prompt: originalPrompt,
-          aspectRatio: taskAspectRatio,
-          resolution: taskResolution,
-          referenceImageIds: referenceImages.map((r) => r.id),
-          retryCount: 0,
-        });
+        for (const itemId of itemIds) {
+          pendingItems.push({
+            id: itemId,
+            status: "pending",
+            modelId,
+            modelName: model.name,
+            prompt: originalPrompt,
+            aspectRatio: taskAspectRatio,
+            resolution: taskResolution,
+            quality: taskQuality,
+            referenceImageIds: referenceImages.map((r) => r.id),
+            retryCount: 0,
+          });
+        }
       }
     }
 
     if (taskSlots.length === 0) return;
-    const taskIds = taskSlots.map((slot) => slot.id);
+    const taskIds = taskSlots.flatMap((slot) => slot.itemIds);
 
     // Show loading cards immediately and register the generation. The prompt-prep
     // pipeline runs concurrently — by the time pending items become `generating`,
@@ -156,7 +174,7 @@ export function useImageGeneration() {
         const taskReplacements = preparedPrompts.variationReplacementsByTask?.[taskIndex];
 
         return {
-          id: slot.id,
+          itemIds: slot.itemIds,
           modelId: slot.modelId,
           modelName: slot.modelName,
           provider: slot.provider,
@@ -165,6 +183,8 @@ export function useImageGeneration() {
           variationReplacements: taskReplacements,
           aspectRatio: slot.aspectRatio,
           resolution: slot.resolution,
+          quality: slot.quality,
+          numberOfImages: slot.numberOfImages,
           referenceImages: referenceImages.map((r) => ({
             id: r.id,
             blob: r.blob,
@@ -176,12 +196,14 @@ export function useImageGeneration() {
       // Patch the already-visible pending items with their final prompt data so
       // the gallery records match what gets sent to the model.
       updatePendingPromptFields(
-        tasks.map((t) => ({
-          id: t.id,
-          prompt: t.prompt,
-          basePrompt: t.basePrompt,
-          variationReplacements: t.variationReplacements,
-        }))
+        tasks.flatMap((t) =>
+          t.itemIds.map((id) => ({
+            id,
+            prompt: t.prompt,
+            basePrompt: t.basePrompt,
+            variationReplacements: t.variationReplacements,
+          }))
+        )
       );
       updatePendingPhase(taskIds, undefined);
 
@@ -194,6 +216,8 @@ export function useImageGeneration() {
     modelSelections,
     aspectRatio,
     resolution,
+    quality,
+    numberOfImages,
     referenceImages,
     models,
     startGeneration,

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -142,6 +142,10 @@ const BASE_BUILT_IN_MODELS: StoredModel[] = [
       supportsResolution: false,
       supportsReferenceImages: true,
       maxReferenceImages: 10,
+      supportsQuality: true,
+      supportedQualities: ["low", "medium", "high", "auto"],
+      supportsNumberOfImages: true,
+      maxImagesPerRequest: 10,
     },
   },
   {

--- a/app/lib/generation.ts
+++ b/app/lib/generation.ts
@@ -17,6 +17,8 @@ export interface GenerationParams {
   prompt: string;
   aspectRatio: AspectRatio | null;
   resolution: Resolution | null;
+  quality: string | null;
+  numberOfImages: number;
   referenceImages: Array<{ id: string; blob: Blob }>;
 }
 
@@ -30,7 +32,7 @@ export interface GenerationResult {
 export async function executeGeneration(
   params: GenerationParams,
   apiKey?: string
-): Promise<GenerationResult> {
+): Promise<GenerationResult[]> {
   const provider = getProvider(params.provider);
   if (!provider.generateImage) {
     throw new Error(`Provider ${params.provider} does not support image generation`);

--- a/app/lib/generationSignature.ts
+++ b/app/lib/generationSignature.ts
@@ -5,6 +5,8 @@ interface GenerationSignatureInput {
   modelSelections: Record<string, number>;
   aspectRatio: AspectRatio | null;
   resolution: Resolution;
+  quality: string | null;
+  numberOfImages: number;
   referenceImages: ReferenceImage[];
 }
 
@@ -20,6 +22,8 @@ export function buildGenerationSignature(input: GenerationSignatureInput): strin
     selections: normalizedSelections,
     aspectRatio: input.aspectRatio,
     resolution: input.resolution,
+    quality: input.quality,
+    numberOfImages: input.numberOfImages,
     referenceImageIds: normalizedReferenceIds,
   });
 }

--- a/app/lib/models.ts
+++ b/app/lib/models.ts
@@ -14,6 +14,9 @@ const PRIMARY_ASPECT_RATIO_VALUES = ASPECT_RATIOS.map((ratio) => ratio.value);
 
 export const RESOLUTIONS = ["1K", "2K", "4K"] as const;
 
+export const QUALITIES = ["low", "medium", "high", "auto"] as const;
+export type Quality = (typeof QUALITIES)[number];
+
 // Helper to get a model by ID from a models array
 export function getModel(models: StoredModel[], modelId: string): StoredModel | undefined {
   return models.find((m) => m.id === modelId);
@@ -148,6 +151,73 @@ export function getStrictReferenceImageLimit(
   }
 
   return Number.isFinite(limit) ? limit : Infinity;
+}
+
+// Helper to check if any selected model supports quality presets
+export function anyModelSupportsQuality(
+  models: StoredModel[],
+  selectedModelIds: string[]
+): boolean {
+  return selectedModelIds.some((modelId) => {
+    const model = getModel(models, modelId);
+    return model?.capabilities.supportsQuality;
+  });
+}
+
+// Intersection of quality enum values across selected quality-aware models.
+export function getQualityIntersection(
+  models: StoredModel[],
+  selectedModelIds: string[]
+): string[] {
+  let intersection: Set<string> | null = null;
+
+  for (const modelId of selectedModelIds) {
+    const model = getModel(models, modelId);
+    if (!model?.capabilities.supportsQuality) continue;
+
+    const qualities = model.capabilities.supportedQualities ?? [...QUALITIES];
+    const qualitySet = new Set(qualities);
+
+    if (!intersection) {
+      intersection = qualitySet;
+      continue;
+    }
+
+    intersection = new Set([...intersection].filter((q) => qualitySet.has(q)));
+  }
+
+  return intersection ? [...intersection] : [];
+}
+
+// Helper to check if any selected model supports batch image generation.
+export function anyModelSupportsNumberOfImages(
+  models: StoredModel[],
+  selectedModelIds: string[]
+): boolean {
+  return selectedModelIds.some((modelId) => {
+    const model = getModel(models, modelId);
+    return model?.capabilities.supportsNumberOfImages;
+  });
+}
+
+// Strictest batch cap across selected batch-aware models. Falls back to 1
+// when no selected model advertises the capability.
+export function getMaxImagesPerRequest(
+  models: StoredModel[],
+  selectedModelIds: string[]
+): number {
+  let limit = Infinity;
+  let sawBatchModel = false;
+
+  for (const modelId of selectedModelIds) {
+    const model = getModel(models, modelId);
+    if (!model?.capabilities.supportsNumberOfImages) continue;
+    sawBatchModel = true;
+    limit = Math.min(limit, model.capabilities.maxImagesPerRequest ?? 1);
+  }
+
+  if (!sawBatchModel) return 1;
+  return Number.isFinite(limit) ? limit : 1;
 }
 
 export function canAttachReferenceCount(

--- a/app/lib/openapi.ts
+++ b/app/lib/openapi.ts
@@ -5,6 +5,8 @@ export interface OpenApiSchemaProperty {
   default?: unknown;
   description?: string;
   title?: string;
+  minimum?: number;
+  maximum?: number;
   $ref?: string;
   allOf?: Array<{ $ref?: string } & Partial<OpenApiSchemaProperty>>;
   anyOf?: Array<{ $ref?: string } & Partial<OpenApiSchemaProperty>>;

--- a/app/lib/prompts.ts
+++ b/app/lib/prompts.ts
@@ -88,6 +88,10 @@ The mapping object has this shape:
   "supportedAspectRatios": ["1:1", "16:9", ...],
   "imageInputKey": "<actual_property_name_for_images>",
   "maxReferenceImages": <number>,
+  "qualityKey": "<actual_property_name_for_quality>",
+  "supportedQualities": ["low", "medium", "high", "auto"],
+  "numberOfImagesKey": "<actual_property_name_for_batch_size>",
+  "maxImagesPerRequest": <number>,
   "extraDefaults": { "<key>": "<value>" }
 }
 
@@ -95,6 +99,8 @@ Our application sends these parameters to Replicate models:
 - resolution: one of "1K", "2K", "4K"
 - aspect_ratio: a string in "W:H" format (e.g. "1:1", "16:9", "9:16", "3:2"), if the model supports aspect ratios
 - image_input: array of base64 data URIs for reference images
+- quality: one of "low", "medium", "high", "auto" (an image quality preset), if the model supports it
+- number_of_images: integer batch size when the model can return multiple coherent images in a single call
 - output_format: "png"
 - prompt: string
 
@@ -104,6 +110,10 @@ Rules:
 - Always include "supportedAspectRatios" if the model has an aspect ratio parameter. List every accepted value as a string in "W:H" format (e.g. "1:1", "16:9", "9:16", "3:2"). Extract values from enum constraints, allowed values in descriptions, or oneOf schemas. If the aspect ratio property exists but has no enum or list of accepted values (open-ended support), set "supportedAspectRatios" to [] — do NOT invent or guess values. If the model has no aspect ratio parameter at all, omit this field entirely.
 - Only include "imageInputKey" if the model uses a property name other than "image_input" for reference images (e.g. "input_images", "image", "init_image")
 - Include "maxReferenceImages" if the schema specifies a maximum number of input/reference images (look in field descriptions for phrases like "Maximum N images" or "up to N"). Omit if no limit is stated.
+- "qualityKey": include ONLY if the model has a string-enum parameter representing image quality (e.g. a property named "quality", "image_quality", "output_quality" or similar with enum values like "low"/"medium"/"high"/"auto", "standard"/"hd", "draft"/"fine", etc.). Set it to the actual property name. Do NOT set this for parameters that look like resolutions, samplers, or inference-step counts.
+- "supportedQualities": include ONLY alongside "qualityKey". List every enum value exactly as the model accepts them (e.g. ["low", "medium", "high", "auto"] or ["standard", "hd"]).
+- "numberOfImagesKey": include ONLY if the model has an integer parameter that controls how many images are produced per single API call in one coherent batch (e.g. "number_of_images", "num_images", "n_images", "num_outputs"). Do NOT set this for sampling-step counts, seeds, or guidance scales.
+- "maxImagesPerRequest": include ONLY alongside "numberOfImagesKey". Use the schema's "maximum" if present, otherwise a conservative integer like 4.
 - Only include "extraDefaults" for parameters with important non-obvious defaults our app doesn't set
 - If there are values in the schema relating to things like safety filters or content restrictions, set them to their most permissive values in "extraDefaults" (e.g. "safety_filter": "off").
 - You should return at least an empty object if all parameters already conform to our schema.

--- a/app/lib/providers/debug.ts
+++ b/app/lib/providers/debug.ts
@@ -36,7 +36,7 @@ function getDebugDimensions(
   };
 }
 
-async function generateImage(params: GenerationParams): Promise<GenerationResult> {
+async function generateImage(params: GenerationParams): Promise<GenerationResult[]> {
   const { width, height } = getDebugDimensions(params.aspectRatio, params.resolution);
   const canvas = document.createElement("canvas");
   canvas.width = width;
@@ -60,31 +60,49 @@ async function generateImage(params: GenerationParams): Promise<GenerationResult
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
 
-  ctx.font = `600 ${headlineSize}px ui-sans-serif, system-ui, sans-serif`;
-  ctx.fillText("DEBUG", width / 2, height / 2 - headlineSize * 0.7);
+  const results: GenerationResult[] = [];
+  const n = Math.max(1, params.numberOfImages);
 
-  ctx.font = `${detailSize}px ui-monospace, monospace`;
-  ctx.fillText(params.modelId, width / 2, height / 2 + detailSize * 0.25);
+  for (let i = 0; i < n; i++) {
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, width, height);
+    ctx.strokeStyle = "#d4d4d8";
+    ctx.strokeRect(0, 0, width, height);
 
-  const promptPreview = params.prompt.trim().slice(0, 80) || "No prompt";
-  ctx.fillStyle = "#52525b";
-  ctx.fillText(promptPreview, width / 2, height / 2 + detailSize * 1.8);
+    ctx.fillStyle = "#18181b";
+    ctx.font = `600 ${headlineSize}px ui-sans-serif, system-ui, sans-serif`;
+    ctx.fillText(
+      n > 1 ? `DEBUG ${i + 1}/${n}` : "DEBUG",
+      width / 2,
+      height / 2 - headlineSize * 0.7
+    );
 
-  await new Promise((resolve) => window.setTimeout(resolve, 350));
+    ctx.font = `${detailSize}px ui-monospace, monospace`;
+    ctx.fillText(params.modelId, width / 2, height / 2 + detailSize * 0.25);
 
-  const blob = await canvasToBlob(canvas);
-  const dimensions = await getImageDimensions(blob);
+    const promptPreview = params.prompt.trim().slice(0, 80) || "No prompt";
+    ctx.fillStyle = "#52525b";
+    ctx.fillText(promptPreview, width / 2, height / 2 + detailSize * 1.8);
 
-  return {
-    blob,
-    width: dimensions.width,
-    height: dimensions.height,
-    metadata: {
-      debug: true,
-      generatedAt: new Date().toISOString(),
-      referenceImageCount: params.referenceImages.length,
-    },
-  };
+    await new Promise((resolve) => window.setTimeout(resolve, 350));
+
+    const blob = await canvasToBlob(canvas);
+    const dimensions = await getImageDimensions(blob);
+
+    results.push({
+      blob,
+      width: dimensions.width,
+      height: dimensions.height,
+      metadata: {
+        debug: true,
+        generatedAt: new Date().toISOString(),
+        referenceImageCount: params.referenceImages.length,
+        batchIndex: i,
+      },
+    });
+  }
+
+  return results;
 }
 
 export const debugProvider: Provider = {

--- a/app/lib/providers/google.ts
+++ b/app/lib/providers/google.ts
@@ -6,7 +6,10 @@ import { toRateLimitError } from "~/lib/retry";
 import { blobToBase64 } from "~/lib/util";
 import type { Provider, SearchResult, TextGenerationArgs } from "./types";
 
-async function generateImage(params: GenerationParams, apiKey?: string): Promise<GenerationResult> {
+async function generateImage(
+  params: GenerationParams,
+  apiKey?: string
+): Promise<GenerationResult[]> {
   if (!apiKey) throw new Error("No API key for google");
   const ai = new GoogleGenAI({ apiKey });
 
@@ -64,12 +67,14 @@ async function generateImage(params: GenerationParams, apiKey?: string): Promise
   if (!imageBlob) throw new Error("No image in response");
   const dimensions = await getImageDimensions(imageBlob);
 
-  return {
-    blob: imageBlob,
-    width: dimensions.width,
-    height: dimensions.height,
-    metadata: { modelVersion },
-  };
+  return [
+    {
+      blob: imageBlob,
+      width: dimensions.width,
+      height: dimensions.height,
+      metadata: { modelVersion },
+    },
+  ];
 }
 
 async function generateText(args: TextGenerationArgs, apiKey: string): Promise<string> {

--- a/app/lib/providers/replicate.ts
+++ b/app/lib/providers/replicate.ts
@@ -16,7 +16,10 @@ function replicateBaseUrl(): string {
   return new URL("/proxy/replicate/v1", window.location.origin).toString();
 }
 
-async function generateImage(params: GenerationParams, apiKey?: string): Promise<GenerationResult> {
+async function generateImage(
+  params: GenerationParams,
+  apiKey?: string
+): Promise<GenerationResult[]> {
   if (!apiKey) throw new Error("No API key for replicate");
   const replicate = new Replicate({ auth: apiKey, baseUrl: replicateBaseUrl() });
 
@@ -26,6 +29,7 @@ async function generateImage(params: GenerationParams, apiKey?: string): Promise
 
   const model = useSettingsStore.getState().models.find((m) => m.id === params.modelId);
   const mapping = model?.schemaMapping;
+  const caps = model?.capabilities;
 
   const input: Record<string, unknown> = {
     prompt: params.prompt,
@@ -42,6 +46,12 @@ async function generateImage(params: GenerationParams, apiKey?: string): Promise
   if (params.resolution) {
     input.resolution = mapping?.resolution?.[params.resolution] ?? params.resolution;
   }
+  if (caps?.supportsQuality && params.quality) {
+    input.quality = params.quality;
+  }
+  if (caps?.supportsNumberOfImages && params.numberOfImages > 1) {
+    input.number_of_images = params.numberOfImages;
+  }
   if (mapping?.extraDefaults) {
     for (const [key, value] of Object.entries(mapping.extraDefaults)) {
       if (!(key in input)) input[key] = value;
@@ -57,23 +67,38 @@ async function generateImage(params: GenerationParams, apiKey?: string): Promise
     throw toRateLimitError(error, "replicate");
   }
 
-  const imageUrl =
-    typeof output === "object" && output !== null && "url" in output
-      ? (output as { url: () => string }).url()
-      : Array.isArray(output)
-        ? output[0]
-        : String(output);
+  // Normalize output to a list of image URLs. Replicate returns either a single
+  // string/FileOutput, or an array of them for batch-capable models.
+  const urls = extractReplicateUrls(output);
+  if (urls.length === 0) throw new Error("No image in Replicate response");
 
-  if (!imageUrl) throw new Error("No image in Replicate response");
+  const results = await Promise.all(
+    urls.map(async (url) => {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch generated image: ${response.status}`);
+      }
+      const blob = await response.blob();
+      const dimensions = await getImageDimensions(blob);
+      return { blob, width: dimensions.width, height: dimensions.height, metadata: {} };
+    })
+  );
 
-  const imageResponse = await fetch(imageUrl);
-  if (!imageResponse.ok)
-    throw new Error(`Failed to fetch generated image: ${imageResponse.status}`);
+  return results;
+}
 
-  const blob = await imageResponse.blob();
-  const dimensions = await getImageDimensions(blob);
-
-  return { blob, width: dimensions.width, height: dimensions.height, metadata: {} };
+function extractReplicateUrls(output: unknown): string[] {
+  if (output == null) return [];
+  if (typeof output === "string") return [output];
+  if (typeof output === "object" && "url" in (output as object)) {
+    const url = (output as { url: () => string }).url();
+    return url ? [url] : [];
+  }
+  if (Array.isArray(output)) {
+    return output.flatMap((entry) => extractReplicateUrls(entry));
+  }
+  const str = String(output);
+  return str ? [str] : [];
 }
 
 async function generateText(args: TextGenerationArgs, apiKey: string): Promise<string> {

--- a/app/lib/providers/replicate.ts
+++ b/app/lib/providers/replicate.ts
@@ -47,10 +47,12 @@ async function generateImage(
     input.resolution = mapping?.resolution?.[params.resolution] ?? params.resolution;
   }
   if (caps?.supportsQuality && params.quality) {
-    input.quality = params.quality;
+    const qualityKey = mapping?.qualityKey ?? "quality";
+    input[qualityKey] = params.quality;
   }
   if (caps?.supportsNumberOfImages && params.numberOfImages > 1) {
-    input.number_of_images = params.numberOfImages;
+    const numberOfImagesKey = mapping?.numberOfImagesKey ?? "number_of_images";
+    input[numberOfImagesKey] = params.numberOfImages;
   }
   if (mapping?.extraDefaults) {
     for (const [key, value] of Object.entries(mapping.extraDefaults)) {
@@ -241,11 +243,15 @@ interface ReplicateModelResponse {
 interface HeuristicResult {
   capabilities: ModelCapabilities;
   detectedAspectRatioKey?: string;
+  detectedQualityKey?: string;
+  detectedNumberOfImagesKey?: string;
 }
 
 interface SchemaAnalysis {
   mapping: SchemaMapping;
   supportedAspectRatios?: string[];
+  supportedQualities?: string[];
+  maxImagesPerRequest?: number;
 }
 
 async function fetchReplicateModelSchema(
@@ -303,14 +309,40 @@ function inferCapabilitiesFromProperties(
     maxReferenceImages = 10;
   }
 
+  const qualityKeys = ["quality", "image_quality", "output_quality"];
+  const detectedQualityKey = qualityKeys.find((key) => {
+    const prop = properties[key];
+    return prop && prop.type === "string" && Array.isArray(prop.enum) && prop.enum.length > 0;
+  });
+  const supportsQuality = !!detectedQualityKey;
+  const supportedQualities = detectedQualityKey ? properties[detectedQualityKey].enum : undefined;
+
+  const numberOfImagesKeys = ["number_of_images", "num_images", "n_images", "num_outputs"];
+  const detectedNumberOfImagesKey = numberOfImagesKeys.find((key) => {
+    const prop = properties[key];
+    return prop && (prop.type === "integer" || prop.type === "number");
+  });
+  const supportsNumberOfImages = !!detectedNumberOfImagesKey;
+  const maxImagesPerRequest = detectedNumberOfImagesKey
+    ? typeof properties[detectedNumberOfImagesKey].maximum === "number"
+      ? properties[detectedNumberOfImagesKey].maximum
+      : 10
+    : undefined;
+
   return {
     capabilities: {
       supportsAspectRatios,
       supportsResolution,
       supportsReferenceImages,
       maxReferenceImages,
+      supportsQuality,
+      ...(supportedQualities ? { supportedQualities } : {}),
+      supportsNumberOfImages,
+      ...(typeof maxImagesPerRequest === "number" ? { maxImagesPerRequest } : {}),
     },
     detectedAspectRatioKey,
+    detectedQualityKey,
+    detectedNumberOfImagesKey,
   };
 }
 
@@ -330,6 +362,8 @@ async function analyzeSchemaWithTextModel(
 
     const mapping: SchemaMapping = {};
     let supportedAspectRatios: string[] | undefined;
+    let supportedQualities: string[] | undefined;
+    let maxImagesPerRequest: number | undefined;
 
     if (parsed.resolution && typeof parsed.resolution === "object") {
       mapping.resolution = parsed.resolution;
@@ -343,6 +377,16 @@ async function analyzeSchemaWithTextModel(
     if (typeof parsed.maxReferenceImages === "number" && parsed.maxReferenceImages > 0) {
       mapping.maxReferenceImages = parsed.maxReferenceImages;
     }
+    if (typeof parsed.qualityKey === "string" && parsed.qualityKey.length > 0) {
+      if (parsed.qualityKey !== "quality") {
+        mapping.qualityKey = parsed.qualityKey;
+      }
+    }
+    if (typeof parsed.numberOfImagesKey === "string" && parsed.numberOfImagesKey.length > 0) {
+      if (parsed.numberOfImagesKey !== "number_of_images") {
+        mapping.numberOfImagesKey = parsed.numberOfImagesKey;
+      }
+    }
     if (parsed.extraDefaults && typeof parsed.extraDefaults === "object") {
       mapping.extraDefaults = parsed.extraDefaults;
     }
@@ -351,13 +395,21 @@ async function analyzeSchemaWithTextModel(
         (v: unknown): v is string => typeof v === "string"
       );
     }
+    if (Array.isArray(parsed.supportedQualities)) {
+      supportedQualities = parsed.supportedQualities.filter(
+        (v: unknown): v is string => typeof v === "string"
+      );
+    }
+    if (typeof parsed.maxImagesPerRequest === "number" && parsed.maxImagesPerRequest > 0) {
+      maxImagesPerRequest = Math.floor(parsed.maxImagesPerRequest);
+    }
 
     const hasMapping = Object.keys(mapping).length > 0;
-    if (!hasMapping && !supportedAspectRatios) {
+    if (!hasMapping && !supportedAspectRatios && !supportedQualities && !maxImagesPerRequest) {
       return null;
     }
 
-    return { mapping, supportedAspectRatios };
+    return { mapping, supportedAspectRatios, supportedQualities, maxImagesPerRequest };
   } catch {
     return null;
   }
@@ -393,6 +445,44 @@ function mergeAnalysis(
 
   if (mapping.resolution && !capabilities.supportsResolution) {
     capabilities.supportsResolution = true;
+  }
+
+  // Quality: the analyzer may have named a non-default property key OR provided
+  // an enum list. The heuristic may have found a default-named `quality` prop.
+  if (mapping.qualityKey && !capabilities.supportsQuality) {
+    const prop = properties[mapping.qualityKey];
+    capabilities.supportsQuality = true;
+    if (!capabilities.supportedQualities && Array.isArray(prop?.enum)) {
+      capabilities.supportedQualities = prop.enum;
+    }
+  } else if (
+    heuristic.detectedQualityKey &&
+    heuristic.detectedQualityKey !== "quality" &&
+    !mapping.qualityKey
+  ) {
+    mapping.qualityKey = heuristic.detectedQualityKey;
+  }
+  if (analysis?.supportedQualities && analysis.supportedQualities.length > 0) {
+    capabilities.supportedQualities = analysis.supportedQualities;
+  }
+
+  // Batch: similar pattern.
+  if (mapping.numberOfImagesKey && !capabilities.supportsNumberOfImages) {
+    const prop = properties[mapping.numberOfImagesKey];
+    capabilities.supportsNumberOfImages = true;
+    if (!capabilities.maxImagesPerRequest) {
+      capabilities.maxImagesPerRequest =
+        typeof prop?.maximum === "number" ? prop.maximum : (analysis?.maxImagesPerRequest ?? 4);
+    }
+  } else if (
+    heuristic.detectedNumberOfImagesKey &&
+    heuristic.detectedNumberOfImagesKey !== "number_of_images" &&
+    !mapping.numberOfImagesKey
+  ) {
+    mapping.numberOfImagesKey = heuristic.detectedNumberOfImagesKey;
+  }
+  if (typeof analysis?.maxImagesPerRequest === "number") {
+    capabilities.maxImagesPerRequest = analysis.maxImagesPerRequest;
   }
 
   const schemaMapping = Object.keys(mapping).length > 0 ? mapping : undefined;

--- a/app/lib/providers/types.ts
+++ b/app/lib/providers/types.ts
@@ -48,7 +48,7 @@ export interface Provider {
   capabilities: ProviderCapabilities;
   supportsTextPrefill?: boolean;
 
-  generateImage?(params: GenerationParams, apiKey?: string): Promise<GenerationResult>;
+  generateImage?(params: GenerationParams, apiKey?: string): Promise<GenerationResult[]>;
   generateText?(args: TextGenerationArgs, apiKey: string): Promise<string>;
   testTextModel?(apiKey: string, modelId: string): Promise<void>;
   upscale?(sourceBlob: Blob, upscaler: StoredUpscaler, apiKey: string): Promise<GenerationResult>;

--- a/app/stores/generationStore.ts
+++ b/app/stores/generationStore.ts
@@ -6,6 +6,8 @@ interface GenerationState {
   currentModelSelections: Record<string, number>;
   currentAspectRatio: AspectRatio | null;
   currentResolution: Resolution;
+  currentQuality: string | null;
+  currentNumberOfImages: number;
   currentReferenceImages: ReferenceImage[];
   variationsEnabled: boolean;
   avoidPastVariations: boolean;
@@ -18,6 +20,8 @@ interface GenerationState {
   setModelCount: (modelId: string, count: number) => void;
   setAspectRatio: (ratio: AspectRatio | null) => void;
   setResolution: (resolution: Resolution) => void;
+  setQuality: (quality: string | null) => void;
+  setNumberOfImages: (count: number) => void;
   setVariationsEnabled: (enabled: boolean) => void;
   setAvoidPastVariations: (enabled: boolean) => void;
   addReferenceImage: (image: ReferenceImage) => void;
@@ -35,6 +39,8 @@ export const DEFAULT_GENERATION_STATE = {
   currentModelSelections: {},
   currentAspectRatio: null,
   currentResolution: "1K" as Resolution,
+  currentQuality: null as string | null,
+  currentNumberOfImages: 1,
   currentReferenceImages: [],
   variationsEnabled: false,
   avoidPastVariations: true,
@@ -60,6 +66,11 @@ export const useGenerationStore = create<GenerationState>()((set) => ({
   setAspectRatio: (currentAspectRatio) => set({ currentAspectRatio }),
 
   setResolution: (currentResolution) => set({ currentResolution }),
+
+  setQuality: (currentQuality) => set({ currentQuality }),
+
+  setNumberOfImages: (currentNumberOfImages) =>
+    set({ currentNumberOfImages: Math.max(1, Math.min(50, currentNumberOfImages)) }),
 
   setVariationsEnabled: (variationsEnabled) => set({ variationsEnabled }),
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -184,6 +184,8 @@ export interface SchemaMapping {
   resolution?: Record<string, string>;
   aspectRatioKey?: string;
   imageInputKey?: string;
+  qualityKey?: string;
+  numberOfImagesKey?: string;
   maxReferenceImages?: number;
   extraDefaults?: Record<string, unknown>;
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -13,6 +13,10 @@ export interface ModelCapabilities {
   resolutions?: Resolution[];
   supportsReferenceImages: boolean;
   maxReferenceImages: number;
+  supportsQuality?: boolean;
+  supportedQualities?: string[];
+  supportsNumberOfImages?: boolean;
+  maxImagesPerRequest?: number;
 }
 
 export interface ModelDefinition {
@@ -83,6 +87,7 @@ export interface BaseGalleryItem {
   variationReplacements?: string[];
   aspectRatio: AspectRatio | null;
   resolution: Resolution | null;
+  quality?: string | null;
   referenceImageIds: string[];
 }
 
@@ -135,6 +140,7 @@ export interface StoredImageRecord {
   modelName: string;
   aspectRatio: AspectRatio | null;
   resolution: Resolution | null;
+  quality?: string | null;
   width: number;
   height: number;
   createdAt: number;


### PR DESCRIPTION
## Summary
This PR adds support for batch image generation (generating multiple images per API call) and quality presets to the generation pipeline. Tasks can now produce multiple gallery items from a single API call, and models that support quality settings can have their quality configured.

## Key Changes

- **Batch Image Generation**: 
  - Changed `GenerationTask.id` to `GenerationTask.itemIds: string[]` to support tasks that produce multiple gallery items
  - Updated `executeTask` to return `GenerationResult[]` instead of a single result
  - Modified `completeTask` to handle multiple results and create corresponding gallery items, with error handling for mismatched result counts
  - Added `numberOfImages` parameter to generation pipeline with model capability constraints

- **Quality Presets**:
  - Added `quality: string | null` and `numberOfImages: number` fields to `GenerationTask` and `GenerationParams`
  - Created new `QualitySection` and `NumberOfImagesSection` UI components for sidebar
  - Added helper functions in `models.ts`: `anyModelSupportsQuality()`, `getQualityIntersection()`, `anyModelSupportsNumberOfImages()`, `getMaxImagesPerRequest()`
  - Updated model capabilities to include `supportsQuality`, `supportedQualities`, `supportsNumberOfImages`, and `maxImagesPerRequest`

- **Provider Updates**:
  - Updated all provider implementations (`debug`, `replicate`, `google`) to return `GenerationResult[]`
  - Added batch image handling in Replicate provider with `extractReplicateUrls()` helper
  - Added quality and numberOfImages parameter passing to API calls

- **Store & State Management**:
  - Added `currentQuality` and `currentNumberOfImages` to `GenerationState`
  - Added `setQuality()` and `setNumberOfImages()` actions
  - Updated `ModelItem` to validate and clamp quality/batch settings when model selection changes

- **Gallery & Generation Flow**:
  - Updated `useImageGeneration` and `useEditorGeneration` to create multiple pending items per task when batch generation is enabled
  - Modified prompt patching to handle multiple items per task
  - Updated generation signature to include quality and numberOfImages for deduplication

## Implementation Details

- Batch items are created upfront with unique IDs and paired with results during completion
- If a model returns fewer results than requested, excess items are marked as failed with a descriptive error
- Quality and batch settings are automatically constrained based on model capabilities and selection
- The debug provider now generates sequential debug images when numberOfImages > 1

https://claude.ai/code/session_011P7Y824AtuVWNgJhfXRnHj