### PR TITLE
feat: OpenAI text model support

### DIFF
--- a/app/components/settings/AddCustomTextModelButton.tsx
+++ b/app/components/settings/AddCustomTextModelButton.tsx
@@ -86,8 +86,9 @@ export default function AddCustomTextModelButton() {
       return;
     }
 
+    const providerInfo = getProvider(provider);
     if (!apiKey) {
-      setError(`Add a ${provider === "google" ? "Google" : "Replicate"} API key first`);
+      setError(`Add a ${providerInfo.label} API key first`);
       return;
     }
 
@@ -99,7 +100,12 @@ export default function AddCustomTextModelButton() {
       await testTextModel(provider, apiKey, trimmed);
       const hit = suggestions.find((s) => s.id === trimmed);
       const name = hit?.name || trimmed;
-      const icon = hit?.icon || (provider === "google" ? "/icons/google.svg" : inferIcon(trimmed));
+      // Replicate models can be arbitrary owner/name combos, so let the icon
+      // heuristic infer from the ID. For first-party providers, prefer the
+      // provider's own icon — `inferIcon` would mis-default to a box for short
+      // names like "o1" that don't match any pattern.
+      const icon =
+        hit?.icon || (provider === "replicate" ? inferIcon(trimmed) : providerInfo.iconPath);
       addCustomTextModel(provider, trimmed, name, icon);
       reset();
     } catch (err) {
@@ -132,7 +138,12 @@ export default function AddCustomTextModelButton() {
     );
   }
 
-  const placeholder = provider === "google" ? "gemini-3-flash-preview" : "owner/model-name";
+  const placeholder =
+    provider === "google"
+      ? "gemini-3-flash-preview"
+      : provider === "openai"
+        ? "gpt-5.4-mini"
+        : "owner/model-name";
 
   return (
     <div className="border-c-border bg-surface-overlay/50 space-y-2 rounded-lg border p-3">

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -244,7 +244,7 @@ export function SettingsModal() {
             <div className="flex items-center gap-2">
               <MessageSquareText className="text-accent-muted h-4 w-4" />
               <span className="text-sm font-medium">Text generation</span>
-              {(apiKeys.google || apiKeys.replicate) && (
+              {(apiKeys.google || apiKeys.replicate || apiKeys.openai) && (
                 <Check className="h-4 w-4 text-green-500" />
               )}
             </div>

--- a/app/components/settings/TextModelItem.tsx
+++ b/app/components/settings/TextModelItem.tsx
@@ -3,6 +3,7 @@ import { useSettingsStore } from "~/stores/settingsStore";
 import SVG from "react-inlinesvg";
 import type { StoredTextModel } from "~/types";
 import { Tooltip } from "~/components/ui/Tooltip";
+import { getProvider } from "~/lib/providers";
 
 export default function TextModelItem({
   model,
@@ -48,11 +49,7 @@ export default function TextModelItem({
         <div className="min-w-0 flex-1">
           <p className="text-text-primary truncate text-sm font-medium">{model.name}</p>
           <div className="mt-0.5 flex items-center gap-1">
-            <Tooltip
-              content={model.provider === "google" ? "Google" : "Replicate"}
-              placement="top"
-              delay={200}
-            >
+            <Tooltip content={getProvider(model.provider).label} placement="top" delay={200}>
               <span className="text-accent-muted bg-accent/50 inline-flex cursor-help items-center gap-1 rounded px-1.5 py-0.5 text-[10px]">
                 <SVG
                   src={`/icons/${model.provider}.svg`}

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -175,6 +175,14 @@ export const BUILT_IN_TEXT_MODELS: StoredTextModel[] = [
     enabled: false,
     icon: "/icons/google.svg",
   },
+  {
+    id: "openai:gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    provider: "openai",
+    modelId: "gpt-5.4-mini",
+    enabled: false,
+    icon: "/icons/openai.svg",
+  },
 ];
 
 export function mergeWithBuiltInTextModels(models?: StoredTextModel[]): StoredTextModel[] {

--- a/app/lib/providers/index.ts
+++ b/app/lib/providers/index.ts
@@ -48,7 +48,7 @@ export function isTextCapable(provider: Provider): provider is TextCapableProvid
     provider.capabilities.text &&
     !!provider.generateText &&
     !!provider.testTextModel &&
-    (provider.id === "google" || provider.id === "replicate")
+    (provider.id === "google" || provider.id === "replicate" || provider.id === "openai")
   );
 }
 

--- a/app/lib/providers/openai.ts
+++ b/app/lib/providers/openai.ts
@@ -3,8 +3,9 @@ import { distance } from "fastest-levenshtein";
 import type { GenerationParams, GenerationResult } from "~/lib/generation";
 import { getImageDimensions } from "~/lib/imageProcessing";
 import { toRateLimitError } from "~/lib/retry";
+import { blobToBase64 } from "~/lib/util";
 import type { AspectRatio, Resolution } from "~/types";
-import type { Provider, ResolvedImageModel, SearchResult } from "./types";
+import type { Provider, ResolvedImageModel, SearchResult, TextGenerationArgs } from "./types";
 import { inferName } from "../modelNames";
 import { normalizeModelId } from ".";
 
@@ -347,20 +348,138 @@ async function searchImageModels(query: string, apiKey: string): Promise<SearchR
   return ranked;
 }
 
+type ResponseInputContent =
+  | { type: "input_text"; text: string }
+  | { type: "input_image"; image_url: string; detail: "auto" | "low" | "high" };
+
+async function generateText(args: TextGenerationArgs, apiKey: string): Promise<string> {
+  let { userPrompt } = args;
+  const { systemPrompt, images, prefill } = args;
+  const modelId = normalizeModelId(args.modelId, "openai");
+  const client = createClient(apiKey);
+
+  // OpenAI models don't reliably continue from a partial assistant turn the way
+  // Gemini does — they treat assistant input as completed history. Fall back to
+  // the Replicate strategy of folding the prefill into the user prompt.
+  if (prefill) {
+    userPrompt = userPrompt + "\n\n" + prefill;
+  }
+
+  const content: ResponseInputContent[] = [{ type: "input_text", text: userPrompt }];
+
+  if (images?.length) {
+    for (const blob of images) {
+      const dataUrl = await blobToBase64(blob);
+      content.push({ type: "input_image", image_url: dataUrl, detail: "auto" });
+    }
+  }
+
+  let response;
+  try {
+    response = await client.responses.create({
+      model: modelId,
+      instructions: systemPrompt,
+      input: [{ role: "user", content }],
+    });
+  } catch (error) {
+    throw toRateLimitError(error, "openai");
+  }
+
+  const text = response.output_text;
+  if (!text) {
+    throw new Error("No text in response");
+  }
+
+  if (prefill) {
+    return prefill + text;
+  }
+  return text;
+}
+
+async function testTextModel(apiKey: string, modelId: string): Promise<void> {
+  await generateText(
+    {
+      modelId,
+      systemPrompt: "You are a connectivity test.",
+      userPrompt: "Respond with the single word 'hi' and nothing else.",
+    },
+    apiKey
+  );
+}
+
+// OpenAI's /v1/models endpoint doesn't expose per-capability flags, so we filter
+// by naming convention. The goal is to allow general-purpose chat/reasoning
+// models and exclude specialized non-text endpoints (images, embeddings, audio,
+// transcription, TTS, realtime, moderation).
+function isTextModel(model: OpenAIModel): boolean {
+  const id = model.id.toLowerCase();
+  if (/(^|[-_])(gpt-image|dall-e)/.test(id)) return false;
+  if (/(^|[-_])embedding/.test(id)) return false;
+  if (/(^|[-_])(whisper|tts|transcribe|audio|realtime|moderation)/.test(id)) return false;
+  // Specialized variants that don't use the standard Responses interface cleanly.
+  if (/(^|[-_])(search-preview|computer-use|deep-research)/.test(id)) return false;
+  // Allow generic gpt-*, chatgpt-*, codex-*, and reasoning models (o1/o3/o4 plus
+  // any future o<N>* family). Tolerate "*-mini", "*-pro", "*-nano", date suffixes.
+  return /^(gpt-|chatgpt-|codex-|o\d)/.test(id);
+}
+
+function toTextSearchResult(model: OpenAIModel): SearchResult {
+  return {
+    id: model.id,
+    name: inferName(model.id),
+    description: model.owned_by ? `Owner: ${model.owned_by}` : "OpenAI text model",
+    icon: "/icons/openai.svg",
+  };
+}
+
+async function searchTextModels(query: string, apiKey: string): Promise<SearchResult[]> {
+  const client = createClient(apiKey);
+
+  let models: OpenAIModel[] = [];
+  try {
+    const response = await client.models.list();
+    models = response.data as OpenAIModel[];
+  } catch {
+    return [];
+  }
+
+  const textModels = models.filter(isTextModel);
+  const q = query.trim().toLowerCase();
+
+  if (!q) {
+    return textModels.slice(0, 6).map(toTextSearchResult);
+  }
+
+  return textModels
+    .map((model) => {
+      const id = model.id.toLowerCase();
+      const containsBoost = id.includes(q) ? -1000 : 0;
+      const score = distance(q, id) + containsBoost;
+      return { model, score };
+    })
+    .sort((a, b) => a.score - b.score)
+    .slice(0, 6)
+    .map(({ model }) => toTextSearchResult(model));
+}
+
 export const openaiProvider: Provider = {
   id: "openai",
   label: "OpenAI",
   iconPath: "/icons/openai.svg",
   requiresApiKey: true,
+  supportsTextPrefill: false,
   capabilities: {
     image: true,
-    text: false,
+    text: true,
     upscale: false,
     searchImage: true,
-    searchText: false,
+    searchText: true,
     searchUpscale: false,
   },
   generateImage,
+  generateText,
+  testTextModel,
   searchImageModels,
+  searchTextModels,
   resolveImageModel,
 };

--- a/app/lib/textModel.ts
+++ b/app/lib/textModel.ts
@@ -4,9 +4,6 @@ import { getProvider } from "~/lib/providers";
 import { logger } from "./logging";
 import { retryWithBackoff } from "./retry";
 
-const DEFAULT_GOOGLE_MODEL = "gemini-3-flash-preview";
-const DEFAULT_REPLICATE_MODEL = "google/gemini-3-flash";
-
 interface ResolvedProvider {
   provider: ApiKeyProvider;
   apiKey: string;
@@ -29,21 +26,27 @@ function resolveProvider(): ResolvedProvider {
     };
   }
 
-  const fallback: ApiKeyProvider = selected.provider === "google" ? "replicate" : "google";
-  if (apiKeys[fallback]) {
-    return {
-      provider: fallback,
-      apiKey: apiKeys[fallback]!,
-      modelId: fallback === "google" ? DEFAULT_GOOGLE_MODEL : DEFAULT_REPLICATE_MODEL,
-    };
+  // The active selection's provider has no key — fall back to the first other
+  // configured text model whose provider has a key. Built-ins are listed first,
+  // so this preserves the historical "prefer Google, then Replicate" order and
+  // naturally extends to OpenAI without hardcoding pairs.
+  for (const fallback of textModels) {
+    if (fallback.id === selected.id) continue;
+    if (apiKeys[fallback.provider]) {
+      return {
+        provider: fallback.provider,
+        apiKey: apiKeys[fallback.provider]!,
+        modelId: fallback.modelId,
+      };
+    }
   }
 
   throw new Error("No API key available for text model");
 }
 
 export function isTextModelAvailable(): boolean {
-  const { apiKeys } = useSettingsStore.getState();
-  return !!(apiKeys.google || apiKeys.replicate);
+  const { apiKeys, textModels } = useSettingsStore.getState();
+  return textModels.some((m) => !!apiKeys[m.provider]);
 }
 
 /**

--- a/app/stores/settingsStore.ts
+++ b/app/stores/settingsStore.ts
@@ -395,7 +395,7 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: "studio-settings",
-      version: 19,
+      version: 20,
       partialize: (state) => ({
         apiKeys: state.apiKeys,
         models: state.models,


### PR DESCRIPTION
Adds OpenAI as a text-generation provider alongside Google and Replicate.
Implements generateText via the Responses API (with vision input as data
URLs), testTextModel, and searchTextModels (filtered to chat/reasoning
models, excluding image/embedding/audio/tts/transcribe/realtime/etc).

Adds a "GPT-5.4 Mini" built-in (disabled by default), bumps the settings
persist version to 20 so existing users pick up the new built-in via the
merge step, and generalizes the text-model resolver fallback to walk the
configured text-model list rather than hardcoding a google<->replicate pair.

Settings UI ("Add custom text model" placeholder/icon/error-label, text
model row provider tag) now drives off the provider registry instead of
two-branch ternaries.

Closes #41