### PR TITLE
feat: polish character creation UX

### DIFF
--- a/app/components/character/CharacterEditView.tsx
+++ b/app/components/character/CharacterEditView.tsx
@@ -1,8 +1,11 @@
 import {
+  AlertTriangle,
   ArrowLeft,
+  CircleAlert,
   ClipboardList,
   ImagePlus,
   Images,
+  Loader2,
   Pencil,
   Sparkles,
   Trash2,
@@ -29,6 +32,7 @@ import {
 import { providerRequiresApiKey } from "~/lib/providers";
 import { callTextModel, isTextModelAvailable } from "~/lib/textModel";
 import { ImproveTextButton } from "../ui/ImproveTextButton";
+import { OptionCombobox } from "../ui/OptionCombobox";
 import { useGalleryStore } from "~/stores/galleryStore";
 import { useGenerationStore } from "~/stores/generationStore";
 import { useSettingsStore } from "~/stores/settingsStore";
@@ -140,40 +144,6 @@ function buildCharacterFormDescription(form: CharacterFormState): string {
   return clothing ? `${description}. Usual clothing/style: ${clothing}.` : `${description}.`;
 }
 
-function FieldWithOptions({
-  label,
-  value,
-  options,
-  onChange,
-}: {
-  label: string;
-  value: string;
-  options: string[];
-  onChange: (value: string) => void;
-}) {
-  const listId = `character-${label.toLowerCase().replace(/\s+/g, "-")}`;
-  return (
-    <div>
-      <label className="text-text-tertiary mb-1.5 block text-xs font-medium tracking-wide uppercase">
-        {label}
-      </label>
-      <input
-        type="text"
-        list={listId}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="Choose or type"
-        className="border-c-border bg-surface-overlay text-text-primary placeholder-text-muted w-full rounded-lg border px-3 py-2 text-sm focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
-      />
-      <datalist id={listId}>
-        {options.map((option) => (
-          <option key={option} value={option} />
-        ))}
-      </datalist>
-    </div>
-  );
-}
-
 function RefTile({ ref: localRef, onRemove }: { ref: LocalRef; onRemove: (id: string) => void }) {
   const openLightbox = useLightboxStore((s) => s.openLightbox);
   return (
@@ -247,6 +217,30 @@ function RecentGalleryStrip({ onAdd }: { onAdd: (item: CompletedGalleryItem) => 
   );
 }
 
+function ModelWarningBanner() {
+  return (
+    <div className="border-yellow-500/30 bg-yellow-500/10 text-yellow-200 flex items-start gap-2 rounded-lg border px-3 py-2 text-xs">
+      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-yellow-300" />
+      <p>
+        Select an image model in the sidebar to generate a reference. Open the sidebar on the left
+        and toggle a model under <span className="font-medium">Models</span>.
+      </p>
+    </div>
+  );
+}
+
+function InlineErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="border-red-500/30 bg-red-500/10 text-red-300 flex items-start gap-2 rounded-lg border px-3 py-2 text-xs"
+    >
+      <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-400" />
+      <p>{message}</p>
+    </div>
+  );
+}
+
 export function CharacterEditView() {
   const { id } = useParams<{ id?: string }>();
   const navigate = useNavigate();
@@ -270,10 +264,13 @@ export function CharacterEditView() {
   const [refs, setRefs] = useState<LocalRef[]>([]);
   const [removedIds, setRemovedIds] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
-  const [generating, setGenerating] = useState(false);
+  const [phase, setPhase] = useState<"idle" | "analyzing" | "generatingImage">("idle");
   const [error, setError] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [form, setForm] = useState<CharacterFormState>(DEFAULT_FORM_STATE);
+  const [extraInstructions, setExtraInstructions] = useState("");
+  const generating = phase !== "idle";
+  const hasImageModelSelected = Object.values(currentModelSelections).some((n) => n > 0);
   const fileRef = useRef<HTMLInputElement>(null);
   const galleryItems = useGalleryStore((s) => s.items);
   const objectUrlsRef = useRef<Set<string>>(new Set());
@@ -481,30 +478,32 @@ export function CharacterEditView() {
       setError("Add at least one reference photo first");
       return;
     }
-
-    const selectedModelId = Object.entries(currentModelSelections).find(
-      ([, count]) => count > 0
-    )?.[0];
-    if (!selectedModelId) {
-      throw new Error("Select an image model in the sidebar first");
+    if (!hasImageModelSelected) {
+      setError("Select an image model in the sidebar first");
+      return;
     }
 
-    setGenerating(true);
     setError(null);
     try {
+      setPhase("analyzing");
+      const trimmedInstructions = extraInstructions.trim();
+      const userMessage = trimmedInstructions
+        ? `Write a reusable character description from these reference images.\n\nAdditional instructions: ${trimmedInstructions}`
+        : "Write a reusable character description from these reference images.";
       const description = await callTextModel(
         CHARACTER_DESCRIPTION_FROM_REFERENCES_SYSTEM,
-        "Write a reusable character description from these reference images.",
+        userMessage,
         refs.map((r) => r.blob)
       );
       setText(description.trim());
       if (!name.trim()) setName("New character");
+      setPhase("generatingImage");
       await generateCharacterReference(description.trim(), refs);
       setMode("manual");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to generate character");
     } finally {
-      setGenerating(false);
+      setPhase("idle");
     }
   };
 
@@ -514,18 +513,22 @@ export function CharacterEditView() {
       setError("Fill out at least one character detail first");
       return;
     }
+    if (!hasImageModelSelected) {
+      setError("Select an image model in the sidebar first");
+      return;
+    }
 
-    setGenerating(true);
     setError(null);
     try {
       if (form.name.trim()) setName(form.name.trim());
       setText(description);
+      setPhase("generatingImage");
       await generateCharacterReference(description);
       setMode("manual");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to generate character reference");
     } finally {
-      setGenerating(false);
+      setPhase("idle");
     }
   };
 
@@ -636,8 +639,12 @@ export function CharacterEditView() {
           e.preventDefault();
           setIsDragOver(false);
         }}
-        className={`min-h-20 rounded-lg border-2 border-dashed p-3 transition-colors ${
-          isDragOver ? "border-purple-500 bg-purple-500/10" : "border-c-border"
+        className={`min-h-20 rounded-lg border-2 p-3 transition-colors ${
+          isDragOver
+            ? "border-dashed border-purple-500 bg-purple-500/10"
+            : refs.length > 0
+              ? "border-c-border/60 border-solid"
+              : "border-c-border border-dashed"
         }`}
       >
         <div className="grid grid-cols-4 gap-2 sm:grid-cols-6">
@@ -688,7 +695,18 @@ export function CharacterEditView() {
             placeholder="Text appended to your prompt when this character is selected (optional)"
             className="border-c-border bg-surface-overlay text-text-primary placeholder-text-muted w-full resize-y rounded-lg border px-3 py-2 text-sm focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
           />
-          <div className="mt-1.5 flex justify-end">
+          <div className="mt-1.5 flex items-center justify-between gap-2">
+            {improveText.error ? (
+              <p
+                role="alert"
+                className="text-xs text-red-400"
+                title={improveText.error}
+              >
+                Couldn’t improve text — {improveText.error}
+              </p>
+            ) : (
+              <span />
+            )}
             <ImproveTextButton
               isImproving={improveText.isImproving}
               hasUndo={improveText.hasUndo}
@@ -707,23 +725,63 @@ export function CharacterEditView() {
 
   const referencesContent = (
     <>
-      <div className="space-y-3">
+      <div className="space-y-4">
+        <header className="flex items-start gap-3">
+          <div className="bg-purple-500/10 text-purple-300 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
+            <Images className="h-4 w-4" />
+          </div>
+          <div>
+            <h2 className="text-text-primary text-sm font-medium">Character from references</h2>
+            <p className="text-text-muted mt-0.5 text-xs">
+              Add photos, then generate a reusable description and one clean reference image.
+            </p>
+          </div>
+        </header>
+
+        {referenceImagesSection}
+
         <div>
-          <h2 className="text-text-primary text-sm font-medium">Character from references</h2>
+          <label
+            htmlFor="character-extra-instructions"
+            className="text-text-tertiary mb-1.5 block text-xs font-medium tracking-wide uppercase"
+          >
+            Additional instructions{" "}
+            <span className="text-text-muted text-[10px] normal-case">(optional)</span>
+          </label>
+          <textarea
+            id="character-extra-instructions"
+            value={extraInstructions}
+            onChange={(e) => setExtraInstructions(e.target.value)}
+            rows={2}
+            placeholder="e.g. focus on hairstyle and outfit, ignore the background"
+            className="border-c-border bg-surface-overlay text-text-primary placeholder-text-muted w-full resize-y rounded-lg border px-3 py-2 text-sm focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
+          />
           <p className="text-text-muted mt-1 text-xs">
-            Add photos, then generate a reusable description and one clean reference image.
+            Guides the text model when it writes the character description from your photos.
           </p>
         </div>
-        {referenceImagesSection}
+
         <RecentGalleryStrip onAdd={addGalleryItem} />
+
+        {!hasImageModelSelected && <ModelWarningBanner />}
+        {error && <InlineErrorBanner message={error} />}
+
         <button
           type="button"
           onClick={handleGenerateFromReferences}
-          disabled={generating}
+          disabled={generating || !hasImageModelSelected}
           className="flex w-full items-center justify-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          <Sparkles className="h-4 w-4" />
-          {generating ? "Generating... (this may take a minute)" : "Generate character"}
+          {generating ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Sparkles className="h-4 w-4" />
+          )}
+          {phase === "analyzing"
+            ? "Analyzing references…"
+            : phase === "generatingImage"
+              ? "Generating reference image…"
+              : "Generate character"}
         </button>
       </div>
     </>
@@ -731,13 +789,18 @@ export function CharacterEditView() {
 
   const formContent = (
     <>
-      <div>
-        <h2 className="text-text-primary text-sm font-medium">Character from form</h2>
-        <p className="text-text-muted mt-1 text-xs">
-          Pick from the suggestions or type custom values; the description is built directly from
-          your entries.
-        </p>
-      </div>
+      <header className="flex items-start gap-3">
+        <div className="bg-purple-500/10 text-purple-300 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
+          <ClipboardList className="h-4 w-4" />
+        </div>
+        <div>
+          <h2 className="text-text-primary text-sm font-medium">Character from form</h2>
+          <p className="text-text-muted mt-0.5 text-xs">
+            Pick from the suggestions or type custom values; the description is built directly from
+            your entries.
+          </p>
+        </div>
+      </header>
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
           <label className="text-text-tertiary mb-1.5 block text-xs font-medium tracking-wide uppercase">
@@ -751,61 +814,61 @@ export function CharacterEditView() {
             className="border-c-border bg-surface-overlay text-text-primary placeholder-text-muted w-full rounded-lg border px-3 py-2 text-sm focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
           />
         </div>
-        <FieldWithOptions
+        <OptionCombobox
           label="Age"
           value={form.age}
           options={FORM_OPTIONS.age}
           onChange={(value) => setForm((prev) => ({ ...prev, age: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Presentation"
           value={form.presentation}
           options={FORM_OPTIONS.presentation}
           onChange={(value) => setForm((prev) => ({ ...prev, presentation: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Eye color"
           value={form.eyeColor}
           options={FORM_OPTIONS.eyeColor}
           onChange={(value) => setForm((prev) => ({ ...prev, eyeColor: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Build"
           value={form.build}
           options={FORM_OPTIONS.build}
           onChange={(value) => setForm((prev) => ({ ...prev, build: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Nationality"
           value={form.nationality}
           options={FORM_OPTIONS.nationality}
           onChange={(value) => setForm((prev) => ({ ...prev, nationality: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Ethnicity"
           value={form.ethnicity}
           options={FORM_OPTIONS.ethnicity}
           onChange={(value) => setForm((prev) => ({ ...prev, ethnicity: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Height"
           value={form.height}
           options={FORM_OPTIONS.height}
           onChange={(value) => setForm((prev) => ({ ...prev, height: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Hair style"
           value={form.hairStyle}
           options={FORM_OPTIONS.hairStyle}
           onChange={(value) => setForm((prev) => ({ ...prev, hairStyle: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Hair color"
           value={form.hairColor}
           options={FORM_OPTIONS.hairColor}
           onChange={(value) => setForm((prev) => ({ ...prev, hairColor: value }))}
         />
-        <FieldWithOptions
+        <OptionCombobox
           label="Skin tone"
           value={form.skinTone}
           options={FORM_OPTIONS.skinTone}
@@ -824,14 +887,20 @@ export function CharacterEditView() {
           />
         </div>
       </div>
+      {!hasImageModelSelected && <ModelWarningBanner />}
+      {error && <InlineErrorBanner message={error} />}
       <button
         type="button"
         onClick={handleGenerateFromForm}
-        disabled={generating}
+        disabled={generating || !hasImageModelSelected}
         className="flex w-full items-center justify-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
       >
-        <Sparkles className="h-4 w-4" />
-        {generating ? "Generating... (this may take a minute)" : "Generate reference"}
+        {generating ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Sparkles className="h-4 w-4" />
+        )}
+        {phase === "generatingImage" ? "Generating reference image…" : "Generate reference"}
       </button>
     </>
   );
@@ -898,7 +967,7 @@ export function CharacterEditView() {
           }}
         />
 
-        {error && <p className="text-xs text-red-400">{error}</p>}
+        {(!isNew || mode === "manual") && error && <InlineErrorBanner message={error} />}
 
         {/* Footer actions */}
         <div className="mt-auto flex gap-2 pt-2">

--- a/app/components/character/CharacterEditView.tsx
+++ b/app/components/character/CharacterEditView.tsx
@@ -11,6 +11,8 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import IconSave from "~icons/dinkie-icons/floppy-disk";
+import IconX from "~icons/dinkie-icons/black-cross-square";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useImproveText } from "~/hooks/useImproveText";
@@ -727,7 +729,7 @@ export function CharacterEditView() {
     <>
       <div className="space-y-4">
         <header className="flex items-start gap-3">
-          <div className="bg-purple-500/10 text-purple-300 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/10 text-purple-300">
             <Images className="h-4 w-4" />
           </div>
           <div>
@@ -770,7 +772,7 @@ export function CharacterEditView() {
           type="button"
           onClick={handleGenerateFromReferences}
           disabled={generating || !hasImageModelSelected}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mx-auto flex items-center justify-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {generating ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -790,7 +792,7 @@ export function CharacterEditView() {
   const formContent = (
     <>
       <header className="flex items-start gap-3">
-        <div className="bg-purple-500/10 text-purple-300 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/10 text-purple-300">
           <ClipboardList className="h-4 w-4" />
         </div>
         <div>
@@ -893,7 +895,7 @@ export function CharacterEditView() {
         type="button"
         onClick={handleGenerateFromForm}
         disabled={generating || !hasImageModelSelected}
-        className="flex w-full items-center justify-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
+        className="mx-auto flex items-center justify-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {generating ? (
           <Loader2 className="h-4 w-4 animate-spin" />
@@ -975,14 +977,16 @@ export function CharacterEditView() {
             type="button"
             onClick={handleSave}
             disabled={saving || generating}
-            className="flex-1 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
           >
+            <IconSave className="h-4 w-4" />
             {saving ? "Saving..." : "Save"}
           </button>
           <Link
             to="/app/settings"
-            className="bg-surface-interactive text-text-secondary hover:bg-c-border rounded-lg px-4 py-2 text-center text-sm font-medium transition-colors"
+            className="bg-surface-interactive text-text-secondary hover:bg-c-border flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-center text-sm font-medium transition-colors"
           >
+            <IconX className="h-4 w-4" />
             Cancel
           </Link>
           {!isNew && existing && (

--- a/app/components/ui/OptionCombobox.tsx
+++ b/app/components/ui/OptionCombobox.tsx
@@ -1,0 +1,79 @@
+import { Combobox } from "@base-ui/react/combobox";
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+
+interface OptionComboboxProps {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function OptionCombobox({
+  label,
+  value,
+  options,
+  onChange,
+  placeholder = "Choose or type",
+}: OptionComboboxProps) {
+  const [open, setOpen] = useState(false);
+
+  const query = value.trim().toLowerCase();
+  const filtered = query
+    ? options.filter((o) => o.toLowerCase().includes(query))
+    : options;
+
+  return (
+    <div>
+      <label className="text-text-tertiary mb-1.5 block text-xs font-medium tracking-wide uppercase">
+        {label}
+      </label>
+      <Combobox.Root
+        open={open}
+        onOpenChange={setOpen}
+        inputValue={value}
+        onInputValueChange={(val) => onChange(val)}
+        filter={null}
+      >
+        <div className="relative">
+          <Combobox.Input
+            placeholder={placeholder}
+            onClick={() => setOpen(true)}
+            onFocus={() => setOpen(true)}
+            className="border-c-border bg-surface-overlay text-text-primary placeholder-text-muted w-full rounded-lg border px-3 py-2 pr-8 text-sm focus:border-purple-500 focus:ring-1 focus:ring-purple-500 focus:outline-none"
+          />
+          <ChevronDown
+            className={`text-text-muted pointer-events-none absolute top-1/2 right-2.5 h-4 w-4 -translate-y-1/2 transition-transform ${
+              open ? "rotate-180" : ""
+            }`}
+          />
+        </div>
+        <Combobox.Portal>
+          <Combobox.Positioner sideOffset={4} align="start" className="z-50">
+            <Combobox.Popup
+              className="border-c-border bg-surface-overlay z-50 max-h-60 overflow-y-auto rounded-lg border py-1 shadow-xl"
+              style={{ width: "var(--anchor-width)" }}
+            >
+              {filtered.length === 0 ? (
+                <p className="text-text-muted px-3 py-2 text-xs">
+                  No matches — keep typing to use a custom value
+                </p>
+              ) : (
+                filtered.map((option) => (
+                  <Combobox.Item
+                    key={option}
+                    value={option}
+                    className="text-text-secondary data-highlighted:bg-surface-raised flex cursor-pointer items-center px-3 py-1.5 text-sm outline-none"
+                  >
+                    {option}
+                  </Combobox.Item>
+                ))
+              )}
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>
+    </div>
+  );
+}

--- a/app/hooks/useImproveText.ts
+++ b/app/hooks/useImproveText.ts
@@ -34,19 +34,21 @@ export function useImproveText({
   const setBaseText = isControlled ? controlledSetBaseText : setLocalBaseText;
 
   const [isImproving, setIsImproving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const improve = useCallback(async () => {
     if (!text.trim() || isImproving) return;
     const snapshot = text;
     setIsImproving(true);
+    setError(null);
     try {
       const images = getImages?.();
       const userPrompt = buildUserPrompt ? buildUserPrompt(text) : text;
       const improved = await callTextModel(systemPrompt, userPrompt, images);
       setText(improved.trim());
       setBaseText(snapshot);
-    } catch {
-      // Leave text unchanged on failure
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to improve text");
     } finally {
       setIsImproving(false);
     }
@@ -58,10 +60,14 @@ export function useImproveText({
     setBaseText(null);
   }, [baseText, setText, setBaseText]);
 
+  const clearError = useCallback(() => setError(null), []);
+
   return {
     isImproving,
     hasUndo: baseText !== null,
     improve,
     undo,
+    error,
+    clearError,
   };
 }

--- a/app/lib/prompts.ts
+++ b/app/lib/prompts.ts
@@ -97,6 +97,7 @@ Rules:
 - Right 1/3rd: 4 rows and 3 columns of smaller reference images. 2 rows of facial expressions and 2 rows of detail close-ups (e.g. hair, distinctive features) for a total of 12 small reference images
 - Use a simple unobtrusive background
 - Prioritize stable physical identity over dramatic scene, lighting, or composition
+- If there is one, preserve the artistic style of the input images. Unify them with consistent lighting and color grading if they differ significantly.
 - Preserve the character's distinctive features exactly where possible, do not simplify or alter them for stylistic effect.
 - Do not include labels, captions, UI, or text in the image`;
 


### PR DESCRIPTION
Address the rough edges in the character creation flow:

- Replace the native <datalist> dropdowns in form mode with an
  OptionCombobox built on @base-ui/react Combobox so the option list
  opens reliably on the first click while still accepting free-form text.
- Surface a yellow banner inside both the references and form modes when
  no image model is toggled in the sidebar, and disable Generate
  accordingly so the requirement is obvious before clicking.
- Split the references flow into "Analyzing references…" and "Generating
  reference image…" phases with a spinner so progress through the
  two-step generation is visible.
- Move error rendering into a red banner directly above each Generate
  button (and into a small inline message under the Improve Text button),
  instead of a single line of red text at the bottom of the view.
- Expose errors from useImproveText so silent failures of the
  improve-text action are visible in the manual editor.
- Add an "Additional instructions" textbox to the references flow that
  gets appended to the user message passed to
  CHARACTER_DESCRIPTION_FROM_REFERENCES_SYSTEM.
- General polish: icon-led headers on each mode, softer border on the
  reference drop zone once images are present, spinner icon on the
  generate buttons.

Closes #49

https://claude.ai/code/session_01K721b2N3ctu9ZzqLfj3Yeg