### PR TITLE
feat: redirect returning users from landing page to app

### DIFF
--- a/app/routes/landing.tsx
+++ b/app/routes/landing.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import type { Route } from "./+types/landing";
+import { useSettingsStore } from "~/stores/settingsStore";
 import IconGithub from "~icons/dinkie-icons/github";
 import IconSparkles from "~icons/dinkie-icons/sparkles";
 import IconBrush from "~icons/dinkie-icons/brush";
@@ -83,6 +84,15 @@ function Feature({
 }
 
 export default function Landing() {
+  const navigate = useNavigate();
+  const isReturningUser = useSettingsStore((s) => s.requestedOutputCount > 0);
+
+  useEffect(() => {
+    if (isReturningUser) {
+      navigate("/app", { replace: true });
+    }
+  }, [isReturningUser, navigate]);
+
   useEffect(() => {
     const html = document.documentElement;
     const body = document.body;
@@ -103,6 +113,8 @@ export default function Landing() {
       body.style.height = prev.bodyHeight;
     };
   }, []);
+
+  if (isReturningUser) return null;
 
   return (
     <div className="min-h-screen bg-[#07070a] text-[#f4f4f7]">


### PR DESCRIPTION
## Summary
Add automatic redirection logic to the landing page that detects returning users and navigates them directly to the app, improving user experience by skipping the landing page for users who have already used the application.

## Changes
- Import `useNavigate` hook from react-router and `useSettingsStore` to access user state
- Add detection logic using `requestedOutputCount` from settings store to identify returning users (those who have previously requested image generation)
- Implement `useEffect` hook that redirects returning users to `/app` route with `replace: true` to prevent back-button navigation to landing
- Add early return (`null`) when user is identified as returning to prevent rendering landing page content

## Implementation Details
- Uses `requestedOutputCount > 0` as the signal for returning users, which is a lifetime counter persisted in `settingsStore`
- Navigation happens via `useEffect` to ensure it occurs after component mount, with proper dependency array `[isReturningUser, navigate]`
- The `replace: true` option ensures the landing page is replaced in browser history rather than pushed, preventing users from navigating back to it

https://claude.ai/code/session_01Y8ZNpH9ybxFvb5UuF7K2hp