### PR TITLE
feat: custom aspect ratio input for gpt-image-2

### DIFF
--- a/app/components/sidebar/AspectRatioSection.tsx
+++ b/app/components/sidebar/AspectRatioSection.tsx
@@ -1,14 +1,20 @@
 import { ChevronRight, Square } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ASPECT_RATIOS,
   getAspectRatioIntersection,
   getAspectRatioUnion,
+  isSoleArbitraryAspectRatioModel,
   parseAspectRatio,
 } from "~/lib/models";
 import { useGenerationStore } from "~/stores/generationStore";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { Accordion } from "@base-ui/react/accordion";
+
+// gpt-image-2 (and any other arbitrary-AR model) requires long:short ≤ 3:1.
+const MAX_LONG_SHORT_RATIO = 3;
+
+const ARBITRARY_MODE_PRESETS = ["3:2", "2:3"];
 
 export function AspectRatioSection() {
   const aspectRatio = useGenerationStore((s) => s.currentAspectRatio);
@@ -20,6 +26,8 @@ export function AspectRatioSection() {
   const selectedModels = Object.entries(modelSelections)
     .filter(([, count]) => count > 0)
     .map(([modelId]) => modelId);
+
+  const arbitraryMode = isSoleArbitraryAspectRatioModel(models, selectedModels);
 
   const selectableRatios = getAspectRatioIntersection(models, selectedModels);
   const visibleRatios = getAspectRatioUnion(models, selectedModels);
@@ -46,13 +54,13 @@ export function AspectRatioSection() {
   const splitAt = primaryRatioValues.length;
   const primaryRatios = allRatios.slice(0, splitAt);
   const hiddenRatios = allRatios.slice(splitAt);
-  const hasAdditionalRatios = selectableRatios.length > splitAt;
+  const hasAdditionalRatios = arbitraryMode || selectableRatios.length > splitAt;
 
-  const renderRatio = (ratio: string) => {
+  const renderRatio = (ratio: string, opts?: { forceEnabled?: boolean }) => {
     const builtInMeta = ASPECT_RATIOS.find((ar) => ar.value === ratio);
     const parsed = parseAspectRatio(ratio);
     const isSelected = aspectRatio === ratio;
-    const isEnabled = selectableSet.has(ratio);
+    const isEnabled = opts?.forceEnabled || selectableSet.has(ratio);
 
     return (
       <button
@@ -102,12 +110,26 @@ export function AspectRatioSection() {
             )}
           </div>
 
-          <div className="grid grid-cols-6 gap-1.5">{primaryRatios.map(renderRatio)}</div>
+          <div className="grid grid-cols-6 gap-1.5">{primaryRatios.map((r) => renderRatio(r))}</div>
 
-          {hiddenRatios.length > 0 && (
+          {arbitraryMode ? (
             <Accordion.Panel className="h-(--accordion-panel-height) overflow-hidden transition-[height] duration-200 data-ending-style:h-0 data-starting-style:h-0">
-              <div className="mt-1.5 grid grid-cols-6 gap-1.5">{hiddenRatios.map(renderRatio)}</div>
+              <div className="mt-1.5 grid grid-cols-6 gap-1.5">
+                {ARBITRARY_MODE_PRESETS.map((r) => renderRatio(r, { forceEnabled: true }))}
+                <CustomAspectRatioInput
+                  currentAspectRatio={aspectRatio}
+                  setAspectRatio={setAspectRatio}
+                />
+              </div>
             </Accordion.Panel>
+          ) : (
+            hiddenRatios.length > 0 && (
+              <Accordion.Panel className="h-(--accordion-panel-height) overflow-hidden transition-[height] duration-200 data-ending-style:h-0 data-starting-style:h-0">
+                <div className="mt-1.5 grid grid-cols-6 gap-1.5">
+                  {hiddenRatios.map((r) => renderRatio(r))}
+                </div>
+              </Accordion.Panel>
+            )
           )}
         </Accordion.Item>
       </Accordion.Root>
@@ -137,5 +159,100 @@ function AspectRatioPreview({
       }`}
       style={{ width: `${w}px`, height: `${h}px` }}
     />
+  );
+}
+
+function parseCustomSeed(aspectRatio: string | null): { w: string; h: string } {
+  if (!aspectRatio) return { w: "3", h: "2" };
+  const [wStr, hStr] = aspectRatio.split(":");
+  const w = Number(wStr);
+  const h = Number(hStr);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) {
+    return { w: "3", h: "2" };
+  }
+  return { w: String(w), h: String(h) };
+}
+
+function CustomAspectRatioInput({
+  currentAspectRatio,
+  setAspectRatio,
+}: {
+  currentAspectRatio: string | null;
+  setAspectRatio: (ratio: string | null) => void;
+}) {
+  const seed = parseCustomSeed(currentAspectRatio);
+  const [wInput, setWInput] = useState(seed.w);
+  const [hInput, setHInput] = useState(seed.h);
+
+  // Keep inputs in sync when an external preset is clicked (e.g. 3:2 / 2:3).
+  useEffect(() => {
+    const next = parseCustomSeed(currentAspectRatio);
+    setWInput(next.w);
+    setHInput(next.h);
+  }, [currentAspectRatio]);
+
+  const wNum = Number(wInput);
+  const hNum = Number(hInput);
+  const numericValid =
+    Number.isFinite(wNum) && Number.isFinite(hNum) && wNum > 0 && hNum > 0;
+  const ratioValid =
+    numericValid && Math.max(wNum, hNum) / Math.min(wNum, hNum) <= MAX_LONG_SHORT_RATIO;
+
+  const candidate = numericValid ? `${wNum}:${hNum}` : null;
+  const isSelected = !!candidate && currentAspectRatio === candidate;
+
+  const apply = (nextW: string, nextH: string) => {
+    const w = Number(nextW);
+    const h = Number(nextH);
+    if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return;
+    if (Math.max(w, h) / Math.min(w, h) > MAX_LONG_SHORT_RATIO) return;
+    setAspectRatio(`${w}:${h}`);
+  };
+
+  const previewW = numericValid ? wNum : 1;
+  const previewH = numericValid ? hNum : 1;
+
+  return (
+    <div
+      className={`col-span-4 flex items-center gap-2 rounded-lg p-1.5 transition-colors ${
+        isSelected
+          ? "border border-purple-500 bg-purple-500/20"
+          : "border-c-border bg-surface-overlay border"
+      }`}
+    >
+      <AspectRatioPreview width={previewW} height={previewH} isSelected={isSelected} />
+      <div className="flex flex-1 items-center gap-1">
+        <input
+          type="number"
+          min={1}
+          step={1}
+          value={wInput}
+          onChange={(e) => {
+            setWInput(e.target.value);
+            apply(e.target.value, hInput);
+          }}
+          aria-label="Custom aspect ratio width"
+          className="bg-surface-interactive text-text-primary focus:ring-purple-500 w-0 min-w-0 flex-1 rounded px-1.5 py-1 text-center text-xs tabular-nums focus:ring-1 focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        />
+        <span className="text-text-tertiary text-xs">:</span>
+        <input
+          type="number"
+          min={1}
+          step={1}
+          value={hInput}
+          onChange={(e) => {
+            setHInput(e.target.value);
+            apply(wInput, e.target.value);
+          }}
+          aria-label="Custom aspect ratio height"
+          className="bg-surface-interactive text-text-primary focus:ring-purple-500 w-0 min-w-0 flex-1 rounded px-1.5 py-1 text-center text-xs tabular-nums focus:ring-1 focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        />
+      </div>
+      {!ratioValid && numericValid && (
+        <span className="text-[10px] text-red-400" title="Long edge must be ≤ 3× short edge">
+          max 3:1
+        </span>
+      )}
+    </div>
   );
 }

--- a/app/components/sidebar/AspectRatioSection.tsx
+++ b/app/components/sidebar/AspectRatioSection.tsx
@@ -11,9 +11,6 @@ import { useGenerationStore } from "~/stores/generationStore";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { Accordion } from "@base-ui/react/accordion";
 
-// gpt-image-2 (and any other arbitrary-AR model) requires long:short ≤ 3:1.
-const MAX_LONG_SHORT_RATIO = 3;
-
 const ARBITRARY_MODE_PRESETS = ["3:2", "2:3"];
 
 export function AspectRatioSection() {
@@ -28,6 +25,9 @@ export function AspectRatioSection() {
     .map(([modelId]) => modelId);
 
   const arbitraryMode = isSoleArbitraryAspectRatioModel(models, selectedModels);
+  const arbitraryMaxLongShort = arbitraryMode
+    ? (models.find((m) => m.id === selectedModels[0])?.capabilities.maxLongShortRatio ?? Infinity)
+    : Infinity;
 
   const selectableRatios = getAspectRatioIntersection(models, selectedModels);
   const visibleRatios = getAspectRatioUnion(models, selectedModels);
@@ -119,6 +119,7 @@ export function AspectRatioSection() {
                 <CustomAspectRatioInput
                   currentAspectRatio={aspectRatio}
                   setAspectRatio={setAspectRatio}
+                  maxLongShortRatio={arbitraryMaxLongShort}
                 />
               </div>
             </Accordion.Panel>
@@ -176,9 +177,11 @@ function parseCustomSeed(aspectRatio: string | null): { w: string; h: string } {
 function CustomAspectRatioInput({
   currentAspectRatio,
   setAspectRatio,
+  maxLongShortRatio,
 }: {
   currentAspectRatio: string | null;
   setAspectRatio: (ratio: string | null) => void;
+  maxLongShortRatio: number;
 }) {
   const seed = parseCustomSeed(currentAspectRatio);
   const [wInput, setWInput] = useState(seed.w);
@@ -196,7 +199,7 @@ function CustomAspectRatioInput({
   const numericValid =
     Number.isFinite(wNum) && Number.isFinite(hNum) && wNum > 0 && hNum > 0;
   const ratioValid =
-    numericValid && Math.max(wNum, hNum) / Math.min(wNum, hNum) <= MAX_LONG_SHORT_RATIO;
+    numericValid && Math.max(wNum, hNum) / Math.min(wNum, hNum) <= maxLongShortRatio;
 
   const candidate = numericValid ? `${wNum}:${hNum}` : null;
   const isSelected = !!candidate && currentAspectRatio === candidate;
@@ -205,9 +208,11 @@ function CustomAspectRatioInput({
     const w = Number(nextW);
     const h = Number(nextH);
     if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return;
-    if (Math.max(w, h) / Math.min(w, h) > MAX_LONG_SHORT_RATIO) return;
+    if (Math.max(w, h) / Math.min(w, h) > maxLongShortRatio) return;
     setAspectRatio(`${w}:${h}`);
   };
+
+  const capLabel = Number.isFinite(maxLongShortRatio) ? `${maxLongShortRatio}:1` : "limit";
 
   const previewW = numericValid ? wNum : 1;
   const previewH = numericValid ? hNum : 1;
@@ -249,8 +254,11 @@ function CustomAspectRatioInput({
         />
       </div>
       {!ratioValid && numericValid && (
-        <span className="text-[10px] text-red-400" title="Long edge must be ≤ 3× short edge">
-          max 3:1
+        <span
+          className="text-[10px] text-red-400"
+          title={`Long edge must be ≤ ${maxLongShortRatio}× short edge`}
+        >
+          max {capLabel}
         </span>
       )}
     </div>

--- a/app/components/sidebar/AspectRatioSection.tsx
+++ b/app/components/sidebar/AspectRatioSection.tsx
@@ -163,13 +163,6 @@ function CustomAspectRatioInput({
   const [wInput, setWInput] = useState(seed.w);
   const [hInput, setHInput] = useState(seed.h);
 
-  // Keep inputs in sync when an external preset is clicked (e.g. 3:2 / 2:3).
-  useEffect(() => {
-    const next = parseCustomSeed(currentAspectRatio);
-    setWInput(next.w);
-    setHInput(next.h);
-  }, [currentAspectRatio]);
-
   const wNum = Number(wInput);
   const hNum = Number(hInput);
   const numericValid =
@@ -180,12 +173,16 @@ function CustomAspectRatioInput({
   const candidate = numericValid ? `${wNum}:${hNum}` : null;
   const isSelected = !!candidate && currentAspectRatio === candidate;
 
+  const handleOnClick = () => {
+    apply(wInput, hInput);
+  };
+
   const apply = (nextW: string, nextH: string) => {
     const w = Number(nextW);
     const h = Number(nextH);
     if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return;
     if (Math.max(w, h) / Math.min(w, h) > maxLongShortRatio) return;
-    setAspectRatio(`${w}:${h}`);
+    setAspectRatio(isSelected ? null : `${w}:${h}`);
   };
 
   const capLabel = Number.isFinite(maxLongShortRatio) ? `${maxLongShortRatio}:1` : "limit";
@@ -194,15 +191,16 @@ function CustomAspectRatioInput({
   const previewH = numericValid ? hNum : 1;
 
   return (
-    <div
-      className={`col-span-4 flex items-center gap-2 rounded-lg p-1.5 transition-colors ${
+    <button
+      className={`relative col-span-3 grid grid-cols-3 items-center justify-items-center gap-4 rounded-lg p-2 transition-colors ${
         isSelected
           ? "border border-purple-500 bg-purple-500/20"
           : "border-c-border bg-surface-overlay border"
       }`}
+      onClick={handleOnClick}
     >
-      <AspectRatioPreview width={previewW} height={previewH} isSelected={isSelected} />
-      <div className="flex flex-1 items-center gap-1">
+      <AspectRatioPreview width={previewW} height={previewH} maxDim={25} isSelected={isSelected} />
+      <div className="col-span-2 flex w-full flex-1 items-center gap-1">
         <input
           type="number"
           min={1}
@@ -213,7 +211,7 @@ function CustomAspectRatioInput({
             apply(e.target.value, hInput);
           }}
           aria-label="Custom aspect ratio width"
-          className="bg-surface-interactive text-text-primary focus:ring-purple-500 w-0 min-w-0 flex-1 rounded px-1.5 py-1 text-center text-xs tabular-nums focus:ring-1 focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          className="bg-surface-interactive text-text-primary w-0 min-w-0 flex-1 [appearance:textfield] rounded px-1.5 py-1 text-center text-xs tabular-nums focus:ring-1 focus:ring-purple-500 focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         />
         <span className="text-text-tertiary text-xs">:</span>
         <input
@@ -226,17 +224,17 @@ function CustomAspectRatioInput({
             apply(wInput, e.target.value);
           }}
           aria-label="Custom aspect ratio height"
-          className="bg-surface-interactive text-text-primary focus:ring-purple-500 w-0 min-w-0 flex-1 rounded px-1.5 py-1 text-center text-xs tabular-nums focus:ring-1 focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          className="bg-surface-interactive text-text-primary w-0 min-w-0 flex-1 [appearance:textfield] rounded px-1.5 py-1 text-center text-xs tabular-nums focus:ring-1 focus:ring-purple-500 focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         />
       </div>
       {!ratioValid && numericValid && (
         <span
-          className="text-[10px] text-red-400"
+          className="absolute bottom-0.5 left-0 right-0 text-[10px] text-red-400"
           title={`Long edge must be ≤ ${maxLongShortRatio}× short edge`}
         >
           max {capLabel}
         </span>
       )}
-    </div>
+    </button>
   );
 }

--- a/app/components/sidebar/ModelItem.tsx
+++ b/app/components/sidebar/ModelItem.tsx
@@ -11,6 +11,7 @@ import {
   getAspectRatioIntersection,
   getMaxImagesPerRequest,
   getQualityIntersection,
+  isSoleArbitraryAspectRatioModel,
 } from "~/lib/models";
 import { PROVIDERS } from "~/lib/providers";
 
@@ -40,6 +41,7 @@ export function ModelItem({ model, count }: ModelItemProps) {
 
     if (
       generationState.currentAspectRatio &&
+      !isSoleArbitraryAspectRatioModel(models, selectedIds) &&
       !getAspectRatioIntersection(models, selectedIds).includes(generationState.currentAspectRatio)
     ) {
       generationState.setAspectRatio(null);

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -90,6 +90,7 @@ export const BUILT_IN_MODELS: StoredModel[] = [
       supportsAspectRatios: true,
       supportedAspectRatios: [],
       allowsArbitraryAspectRatio: true,
+      maxLongShortRatio: 3,
       supportsResolution: true,
       supportsReferenceImages: true,
       maxReferenceImages: 16,

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -89,6 +89,7 @@ export const BUILT_IN_MODELS: StoredModel[] = [
     capabilities: {
       supportsAspectRatios: true,
       supportedAspectRatios: [],
+      allowsArbitraryAspectRatio: true,
       supportsResolution: true,
       supportsReferenceImages: true,
       maxReferenceImages: 16,

--- a/app/lib/models.ts
+++ b/app/lib/models.ts
@@ -102,6 +102,17 @@ export function getAspectRatioIntersection(
   return intersection ? [...intersection] : [];
 }
 
+// True when exactly one model is selected and it accepts arbitrary aspect ratios.
+// Used to enable the custom WxH picker UI.
+export function isSoleArbitraryAspectRatioModel(
+  models: StoredModel[],
+  selectedModelIds: string[]
+): boolean {
+  if (selectedModelIds.length !== 1) return false;
+  const model = getModel(models, selectedModelIds[0]);
+  return !!model?.capabilities.allowsArbitraryAspectRatio;
+}
+
 export function getAspectRatioUnion(models: StoredModel[], selectedModelIds: string[]): string[] {
   if (selectedModelIds.length === 0) {
     return PRIMARY_ASPECT_RATIO_VALUES;

--- a/app/lib/models.ts
+++ b/app/lib/models.ts
@@ -55,6 +55,13 @@ export function doesModelSupportAspectRatio(model: StoredModel, aspectRatio: str
     return false;
   }
 
+  if (model.capabilities.allowsArbitraryAspectRatio) {
+    const { width, height } = parseAspectRatio(aspectRatio);
+    const longShort = Math.max(width, height) / Math.min(width, height);
+    const cap = model.capabilities.maxLongShortRatio ?? Infinity;
+    return longShort <= cap;
+  }
+
   const supportedRatios = getSupportedAspectRatiosForModel(model);
   return supportedRatios.length === 0 || supportedRatios.includes(aspectRatio);
 }
@@ -79,27 +86,26 @@ export function getAspectRatioIntersection(
     return PRIMARY_ASPECT_RATIO_VALUES;
   }
 
-  let intersection: Set<string> | null = null;
+  const selectedModels = selectedModelIds
+    .map((id) => getModel(models, id))
+    .filter((m): m is StoredModel => !!m);
 
-  for (const modelId of selectedModelIds) {
-    const model = getModel(models, modelId);
-    if (!model) continue;
+  if (selectedModels.length === 0) return [];
+  if (selectedModels.some((m) => !m.capabilities.supportsAspectRatios)) return [];
 
-    const modelRatios = getSupportedAspectRatiosForModel(model);
-    if (modelRatios.length === 0) {
-      return [];
+  // Candidate universe: primaries plus any explicit ratios that non-arbitrary
+  // models declare. Arbitrary-AR models don't contribute concrete extras —
+  // they're filtered in via the predicate below.
+  const candidates = new Set<string>(PRIMARY_ASPECT_RATIO_VALUES);
+  for (const m of selectedModels) {
+    if (!m.capabilities.allowsArbitraryAspectRatio) {
+      for (const r of getSupportedAspectRatiosForModel(m)) candidates.add(r);
     }
-
-    const modelSet = new Set(modelRatios);
-    if (!intersection) {
-      intersection = modelSet;
-      continue;
-    }
-
-    intersection = new Set([...intersection].filter((ratio) => modelSet.has(ratio)));
   }
 
-  return intersection ? [...intersection] : [];
+  return [...candidates].filter((r) =>
+    selectedModels.every((m) => doesModelSupportAspectRatio(m, r))
+  );
 }
 
 // True when exactly one model is selected and it accepts arbitrary aspect ratios.

--- a/app/stores/settingsStore.ts
+++ b/app/stores/settingsStore.ts
@@ -395,7 +395,7 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: "studio-settings",
-      version: 20,
+      version: 21,
       partialize: (state) => ({
         apiKeys: state.apiKeys,
         models: state.models,

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -9,6 +9,8 @@ export type Resolution = "1K" | "2K" | "4K";
 export interface ModelCapabilities {
   supportsAspectRatios: boolean;
   supportedAspectRatios?: string[]; // should use doesModelSupportAspectRatio() from models.ts to check support
+  /** Model accepts any aspect ratio string within its own internal constraints (e.g. gpt-image-2). */
+  allowsArbitraryAspectRatio?: boolean;
   supportsResolution: boolean;
   resolutions?: Resolution[];
   supportsReferenceImages: boolean;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -11,6 +11,8 @@ export interface ModelCapabilities {
   supportedAspectRatios?: string[]; // should use doesModelSupportAspectRatio() from models.ts to check support
   /** Model accepts any aspect ratio string within its own internal constraints (e.g. gpt-image-2). */
   allowsArbitraryAspectRatio?: boolean;
+  /** For arbitrary-AR models, the maximum long:short edge ratio (e.g. 3 for gpt-image-2's 3:1 cap). */
+  maxLongShortRatio?: number;
   supportsResolution: boolean;
   resolutions?: Resolution[];
   supportsReferenceImages: boolean;


### PR DESCRIPTION
## Summary

When `gpt-image-2` is the only selected model, the aspect-ratio picker's "Show more" panel now exposes:

- `3:2` and `2:3` preset buttons (one slot each)
- A custom W:H input widget spanning the remaining 4 slots, with two number fields, a live aspect-ratio preview, and inline validation against the model's 3:1 long-edge limit.

The custom value flows through the existing free-form `AspectRatio` string and is resolved into a concrete `WxH` size at API call time by `resolveGptImage2Size` in `app/lib/providers/openai.ts` — no backend changes were required.

## Implementation notes

- New `allowsArbitraryAspectRatio` capability on `ModelCapabilities`, set on `openai/gpt-image-2`. The existing empty-`supportedAspectRatios` fallback (which renders the 6 primary presets) stays as-is, so the main grid is unchanged.
- New helper `isSoleArbitraryAspectRatioModel(models, selectedIds)` gates the extra UI to "exactly one selected model, and it allows arbitrary ARs".
- `ModelItem.tsx`'s selection-change reset now skips the AR clear when the user is in arbitrary mode, so a custom value like `5:4` survives unrelated re-selections.

## Test plan

- [ ] Select only **GPT Image 2** → "Show more" appears; expanded panel shows the 6 primary presets above and `3:2` / `2:3` + custom input below.
- [ ] Clicking `3:2` / `2:3` selects them; clicking again deselects.
- [ ] Typing `5` / `4` sets `currentAspectRatio` to `5:4`, the preview rectangle updates, and the widget shows the purple selected styling.
- [ ] Typing a `>3:1` ratio (e.g. `10` / `1`) shows the inline "max 3:1" warning and does **not** apply the value.
- [ ] Generate with a custom ratio → OpenAI receives a valid `WxH` size (DevTools → Network), output dimensions match the ratio.
- [ ] Adding a second model removes the custom UI; the custom AR value is preserved if still valid, cleared only when no longer in the intersection.

Closes #52

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3zF7CeqruxvhZtsCUZD8D)_