### PR TITLE
feat: show supported aspect ratios in model chip tooltip

### DIFF
--- a/app/components/settings/ModelToggle.tsx
+++ b/app/components/settings/ModelToggle.tsx
@@ -10,28 +10,66 @@ import {
 } from "lucide-react";
 import { useSettingsStore } from "~/stores/settingsStore";
 import SVG from "react-inlinesvg";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import type { StoredModel } from "~/types";
 import { Tooltip } from "~/components/ui/Tooltip";
 import { Switch } from "~/components/ui/Switch";
+import { AspectRatioPreview } from "~/components/ui/AspectRatioPreview";
 import { getProvider, normalizeModelId, providerRequiresApiKey, PROVIDERS } from "~/lib/providers";
+import { getSupportedAspectRatiosForModel, parseAspectRatio } from "~/lib/models";
 
 function CapabilityBadge({
   icon: Icon,
   label,
   enabled,
+  maxWidth,
 }: {
   icon: React.ElementType;
-  label: string;
+  label: ReactNode;
   enabled: boolean;
+  maxWidth?: string;
 }) {
   if (!enabled) return null;
   return (
-    <Tooltip content={label} placement="top" delay={200}>
+    <Tooltip content={label} placement="top" delay={200} maxWidth={maxWidth}>
       <span className="bg-surface-interactive/50 text-text-tertiary inline-flex cursor-help items-center gap-1 rounded px-1.5 py-0.5 text-[10px]">
         <Icon className="h-2.5 w-2.5" />
       </span>
     </Tooltip>
+  );
+}
+
+function AspectRatioTooltipContent({ model }: { model: StoredModel }) {
+  if (!model.capabilities.supportsAspectRatios) return null;
+
+  const isArbitrary =
+    Array.isArray(model.capabilities.supportedAspectRatios) &&
+    model.capabilities.supportedAspectRatios.length === 0;
+
+  if (isArbitrary) {
+    return <span>Arbitrary aspect ratios supported</span>;
+  }
+
+  const ratios = [...getSupportedAspectRatiosForModel(model)].sort((a, b) => {
+    const aParsed = parseAspectRatio(a);
+    const bParsed = parseAspectRatio(b);
+    return bParsed.width / bParsed.height - aParsed.width / aParsed.height;
+  });
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {ratios.map((ratio) => {
+        const { width, height } = parseAspectRatio(ratio);
+        return (
+          <div key={ratio} className="flex flex-col items-center gap-0.5">
+            <div className="flex h-[18px] items-center justify-center">
+              <AspectRatioPreview width={width} height={height} maxDim={16} />
+            </div>
+            <span className="text-text-tertiary text-[10px] leading-none">{ratio}</span>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -125,8 +163,9 @@ export default function ModelToggleItem({
           </Tooltip>
           <CapabilityBadge
             icon={RectangleHorizontal}
-            label="Aspect ratio"
+            label={<AspectRatioTooltipContent model={model} />}
             enabled={capabilities.supportsAspectRatios}
+            maxWidth="max-w-72"
           />
           <CapabilityBadge
             icon={Maximize}

--- a/app/components/sidebar/AspectRatioSection.tsx
+++ b/app/components/sidebar/AspectRatioSection.tsx
@@ -9,6 +9,7 @@ import {
 import { useGenerationStore } from "~/stores/generationStore";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { Accordion } from "@base-ui/react/accordion";
+import { AspectRatioPreview } from "~/components/ui/AspectRatioPreview";
 
 export function AspectRatioSection() {
   const aspectRatio = useGenerationStore((s) => s.currentAspectRatio);
@@ -115,27 +116,3 @@ export function AspectRatioSection() {
   );
 }
 
-function AspectRatioPreview({
-  width,
-  height,
-  isSelected,
-}: {
-  width: number;
-  height: number;
-  isSelected: boolean;
-}) {
-  // Normalize to max dimension of 20px
-  const maxDim = 20;
-  const scale = maxDim / Math.max(width, height);
-  const w = Math.round(width * scale);
-  const h = Math.round(height * scale);
-
-  return (
-    <div
-      className={`rounded-sm border-2 ${
-        isSelected ? "border-purple-500 bg-purple-500/20" : "border-c-border"
-      }`}
-      style={{ width: `${w}px`, height: `${h}px` }}
-    />
-  );
-}

--- a/app/components/ui/AspectRatioPreview.tsx
+++ b/app/components/ui/AspectRatioPreview.tsx
@@ -1,0 +1,24 @@
+export function AspectRatioPreview({
+  width,
+  height,
+  isSelected = false,
+  maxDim = 20,
+}: {
+  width: number;
+  height: number;
+  isSelected?: boolean;
+  maxDim?: number;
+}) {
+  const scale = maxDim / Math.max(width, height);
+  const w = Math.round(width * scale);
+  const h = Math.round(height * scale);
+
+  return (
+    <div
+      className={`rounded-sm border-2 ${
+        isSelected ? "border-purple-500 bg-purple-500/20" : "border-c-border"
+      }`}
+      style={{ width: `${w}px`, height: `${h}px` }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Capability chip under each model in Settings now lists every supported aspect ratio with the same small rectangle previews used in the sidebar AR picker — making visually similar ratios like `8:1` vs `1:8` unambiguous.
- Models that declare arbitrary ratio support (GPT Image 2, `supportedAspectRatios: []`) show a short "Arbitrary aspect ratios supported" message.
- Extracted `AspectRatioPreview` into `app/components/ui/` so the picker and the tooltip share one component (no visual regression in the picker).
- Resolution chip left unchanged — per-model resolution lists aren't stored anywhere in the codebase today.

## Test plan
- [ ] `pnpm dev`, open Settings → Models, hover each built-in model's aspect-ratio chip:
  - Gemini 3.0 Pro: 10 ratios
  - Gemini 3.1 Flash: 14 ratios (`1:8` and `8:1` previews are visually distinct)
  - GPT Image 2: "Arbitrary aspect ratios supported"
  - Nano Banana Pro / Flux 2 Flex / Seedream 4.5: their respective lists
- [ ] Open the sidebar aspect ratio picker — preview rectangles look identical to before.
- [ ] `pnpm typecheck` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ld9u617H6v2FJEddcgox6G)_