### PR TITLE
feat: remove "auto" quality option from gpt-image-2 picker

### DIFF
--- a/app/components/sidebar/QualitySection.tsx
+++ b/app/components/sidebar/QualitySection.tsx
@@ -8,7 +8,6 @@ const QUALITY_LABELS: Record<string, string> = {
   low: "Low",
   medium: "Medium",
   high: "High",
-  auto: "Auto",
 };
 
 export function QualitySection() {

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -95,7 +95,7 @@ export const BUILT_IN_MODELS: StoredModel[] = [
       supportsReferenceImages: true,
       maxReferenceImages: 16,
       supportsQuality: true,
-      supportedQualities: ["low", "medium", "high", "auto"],
+      supportedQualities: ["low", "medium", "high"],
       supportsNumberOfImages: true,
       maxImagesPerRequest: 10,
     },

--- a/app/lib/models.ts
+++ b/app/lib/models.ts
@@ -18,7 +18,7 @@ export const RESOLUTIONS_LABELS: [string, Resolution][] = [
   ["Ultra", "4K"],
 ];
 
-export const QUALITIES = ["low", "medium", "high", "auto"] as const;
+export const QUALITIES = ["low", "medium", "high"] as const;
 export type Quality = (typeof QUALITIES)[number];
 
 // Helper to get a model by ID from a models array

--- a/app/lib/providers/openai.ts
+++ b/app/lib/providers/openai.ts
@@ -241,7 +241,7 @@ function inferOpenAiImageCapabilities(modelId: string): ResolvedImageModel["capa
       supportsReferenceImages: true,
       maxReferenceImages: 16,
       supportsQuality: true,
-      supportedQualities: ["low", "medium", "high", "auto"],
+      supportedQualities: ["low", "medium", "high"],
       supportsNumberOfImages: true,
       maxImagesPerRequest: 10,
     };
@@ -254,7 +254,7 @@ function inferOpenAiImageCapabilities(modelId: string): ResolvedImageModel["capa
     supportsReferenceImages: true,
     maxReferenceImages: 16,
     supportsQuality: true,
-    supportedQualities: ["low", "medium", "high", "auto"],
+    supportedQualities: ["low", "medium", "high"],
     supportsNumberOfImages: true,
     maxImagesPerRequest: 10,
   };


### PR DESCRIPTION
## Summary

- Removes the **Auto** button from the Quality picker for gpt-image-2
- `"auto"` is OpenAI's default when no `quality` param is sent, so selecting it is identical to selecting nothing — the button added noise without value

## Changes

| File | Change |
|------|--------|
| `app/lib/models.ts` | Remove `"auto"` from `QUALITIES` constant |
| `app/lib/builtInModels.ts` | Remove `"auto"` from gpt-image-2 `supportedQualities` |
| `app/lib/providers/openai.ts` | Remove `"auto"` from both spots in `inferOpenAiImageCapabilities()` |
| `app/components/sidebar/QualitySection.tsx` | Remove `auto: "Auto"` from `QUALITY_LABELS` |

No migration required — `currentQuality` is not persisted, and any existing stored gallery items with `quality: "auto"` continue to work at the API level.

## Validation

- Select gpt-image-2 in the sidebar → Quality section shows Low / Medium / High only (no Auto)
- Generate with no quality selected → API omits `quality` param → OpenAI uses its "auto" default
- Generate with Low/Medium/High selected → quality param passed as expected

Closes #59