### PR TITLE
feat: include characters and custom styles in export/import ZIP

### DIFF
--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -333,6 +333,10 @@ function DataSection() {
       const parts = [`${result.imported} generations imported`];
       if (result.referencesImported > 0)
         parts.push(`${result.referencesImported} references imported`);
+      if (result.charactersImported > 0)
+        parts.push(`${result.charactersImported} character${result.charactersImported !== 1 ? "s" : ""} imported`);
+      if (result.stylesImported > 0)
+        parts.push(`${result.stylesImported} custom style${result.stylesImported !== 1 ? "s" : ""} imported`);
       if (result.skipped > 0) parts.push(`${result.skipped} skipped (already exist)`);
       if (result.failed > 0) parts.push(`${result.failed} failed`);
       setStatus(parts.join(", "));
@@ -360,7 +364,7 @@ function DataSection() {
 
       <div className="border-border-subtle bg-surface-raised/60 ml-6 space-y-3 rounded-lg border p-3">
         <p className="text-text-muted text-xs">
-          Export or import all images and their metadata as a ZIP file.
+          Export or import all images, characters, and custom styles as a ZIP file.
           {imageCount !== null && (
             <span className="text-text-tertiary ml-1">
               {imageCount} image{imageCount !== 1 ? "s" : ""} in gallery.

--- a/app/lib/exportImport.ts
+++ b/app/lib/exportImport.ts
@@ -1,6 +1,6 @@
 import JSZip from "jszip";
 import mime from "mime/lite";
-import type { StoredImageRecord } from "~/types";
+import type { StoredCharacter, StoredImageRecord, StoredStyle } from "~/types";
 import {
   getAllImages,
   getAllReferenceImages,
@@ -10,6 +10,7 @@ import {
   saveReferenceImage,
 } from "./db";
 import { createThumbnailBlob } from "./imageProcessing";
+import { useSettingsStore } from "~/stores/settingsStore";
 
 // Derived from StoredImageRecord so any new field added there is automatically
 // included in the export manifest. Only the binary blobs are stripped (they
@@ -65,6 +66,11 @@ export async function exportAllImages(
   }
   zip.file("references-manifest.json", JSON.stringify(referencesManifest, null, 2));
 
+  const { characters, styles } = useSettingsStore.getState();
+  zip.file("characters.json", JSON.stringify(characters, null, 2));
+  const customStyles = styles.filter((s) => s.isCustom);
+  zip.file("custom-styles.json", JSON.stringify(customStyles, null, 2));
+
   const blob = await zip.generateAsync({ type: "blob" });
   const date = new Date().toISOString().slice(0, 10);
   const url = URL.createObjectURL(blob);
@@ -80,6 +86,8 @@ export async function exportAllImages(
 export interface ImportResult {
   imported: number;
   referencesImported: number;
+  charactersImported: number;
+  stylesImported: number;
   skipped: number;
   failed: number;
 }
@@ -99,7 +107,14 @@ export async function importFromZip(
   const manifest: ManifestEntry[] = JSON.parse(manifestText);
 
   const existingIds = await getExistingImageIds();
-  const result: ImportResult = { imported: 0, referencesImported: 0, skipped: 0, failed: 0 };
+  const result: ImportResult = {
+    imported: 0,
+    referencesImported: 0,
+    charactersImported: 0,
+    stylesImported: 0,
+    skipped: 0,
+    failed: 0,
+  };
 
   for (let i = 0; i < manifest.length; i++) {
     const entry = manifest[i];
@@ -177,6 +192,25 @@ export async function importFromZip(
         result.failed++;
       }
     }
+  }
+
+  const { importCharacters, importCustomStyles } = useSettingsStore.getState();
+
+  const charsFile = zip.file("characters.json");
+  if (charsFile) {
+    const chars: StoredCharacter[] = JSON.parse(await charsFile.async("text"));
+    const before = useSettingsStore.getState().characters.length;
+    importCharacters(chars);
+    result.charactersImported = useSettingsStore.getState().characters.length - before;
+  }
+
+  const stylesFile = zip.file("custom-styles.json");
+  if (stylesFile) {
+    const importedStyles: StoredStyle[] = JSON.parse(await stylesFile.async("text"));
+    const before = useSettingsStore.getState().styles.filter((s) => s.isCustom).length;
+    importCustomStyles(importedStyles);
+    result.stylesImported =
+      useSettingsStore.getState().styles.filter((s) => s.isCustom).length - before;
   }
 
   return result;

--- a/app/stores/settingsStore.ts
+++ b/app/stores/settingsStore.ts
@@ -85,6 +85,8 @@ interface SettingsState {
   ) => void;
   removeCharacter: (id: string) => void;
   reorderCharacters: (activeId: string, overId: string) => void;
+  importCharacters: (characters: StoredCharacter[]) => void;
+  importCustomStyles: (styles: StoredStyle[]) => void;
 
   // Text model actions
   selectTextModel: (id: string) => void;
@@ -375,6 +377,20 @@ export const useSettingsStore = create<SettingsState>()(
           const [moved] = newCharacters.splice(oldIndex, 1);
           newCharacters.splice(newIndex, 0, moved);
           return { characters: newCharacters };
+        }),
+
+      importCharacters: (incoming) =>
+        set((state) => {
+          const existingIds = new Set(state.characters.map((c) => c.id));
+          const newOnes = incoming.filter((c) => !existingIds.has(c.id));
+          return newOnes.length ? { characters: [...state.characters, ...newOnes] } : state;
+        }),
+
+      importCustomStyles: (incoming) =>
+        set((state) => {
+          const existingIds = new Set(state.styles.map((s) => s.id));
+          const newOnes = incoming.filter((s) => !existingIds.has(s.id));
+          return newOnes.length ? { styles: [...state.styles, ...newOnes] } : state;
         }),
 
       setDesktopNotificationsEnabled: (enabled) => set({ desktopNotificationsEnabled: enabled }),


### PR DESCRIPTION
## Summary

- Adds `characters.json` and `custom-styles.json` to the export ZIP so user-defined characters and custom styles survive a backup/restore cycle
- On import, merges incoming characters and styles by ID — skips any that already exist (no duplicates)
- Updates the import result summary to report how many characters and custom styles were imported
- Updates the Data section description to reflect the broader export scope

Character reference images were already exported as part of the `references/` directory (since `getAllReferenceImages()` fetches the full IndexedDB store), so no change to that path was needed.

Closes #60

## Validation steps

- [ ] Export a ZIP with characters and custom styles defined — confirm `characters.json` and `custom-styles.json` are present inside the archive
- [ ] Clear characters/styles in settings, then import the ZIP — confirm characters and custom styles reappear and the success message includes counts
- [ ] Import the same ZIP a second time — confirm no duplicates are created and counts show 0
- [ ] Verify character reference images still work after a round-trip (images load in character detail)
- [ ] Confirm importing a legacy ZIP (no `characters.json`/`custom-styles.json`) still succeeds

## Checklist

- [x] Dedup on import (skip existing IDs)
- [x] Import result surfaces character/style counts in the UI toast
- [x] Description copy updated
- [x] No changes to persisted store version required (new actions, no schema change)