### PR TITLE
feat: settings redesign with sidebar TOC and reorganised sections

### DIFF
--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -177,8 +177,7 @@ export function SettingsModal() {
   const handleCharacterDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event;
-      if (over && active.id !== over.id)
-        reorderCharacters(active.id as string, over.id as string);
+      if (over && active.id !== over.id) reorderCharacters(active.id as string, over.id as string);
     },
     [reorderCharacters]
   );

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -8,7 +8,6 @@ import {
   Archive,
   Download,
   Upload,
-  Sparkles,
   Layers,
   Users,
   Palette,

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -4,7 +4,6 @@ import {
   EyeOff,
   Check,
   Loader2,
-  Bell,
   MessageSquareText,
   Archive,
   Download,
@@ -189,7 +188,7 @@ export function SettingsModal() {
     <main className="bg-surface flex h-full flex-1 flex-col overflow-hidden">
       <GalleryHeader title="Settings" />
 
-      <div className="flex-1 space-y-6 overflow-y-auto p-4">
+      <div id="settings-scroll" className="flex-1 space-y-6 overflow-y-auto p-4">
         {/* API Keys */}
         <section id="api-keys" className="group space-y-3">
           <div className="flex items-center gap-2">
@@ -355,64 +354,57 @@ export function SettingsModal() {
             <span className="text-sm font-medium">Gallery</span>
           </div>
 
-          <div className="space-y-3 pl-6">
-            <div className="border-border-subtle bg-surface-raised/60 space-y-3 rounded-lg border p-3">
-              <label className="flex items-center justify-between gap-3">
-                <span className="text-text-secondary text-sm">Enable semantic image search</span>
-                <Switch
-                  checked={semanticSearchEnabled}
-                  onChange={(e) => handleToggleSemanticSearch(e.target.checked)}
-                  aria-label="Toggle semantic image search"
-                />
-              </label>
-              <p className="text-text-muted text-xs">
-                Downloads a ~400MB model on first use and runs it locally. Embeddings are computed
-                in the background while you wait for generations and let you search by image content
-                as well as prompt text. All processing stays in your browser.
-              </p>
-              {semanticSearchEnabled && <SemanticSearchStatus />}
-            </div>
+          <div className="pl-6">
+            <div className="border-border-subtle bg-surface-raised/60 divide-border-subtle divide-y rounded-lg border">
+              <div className="space-y-3 p-3">
+                <label className="flex items-center justify-between gap-3">
+                  <span className="text-text-secondary text-sm">Enable semantic image search</span>
+                  <Switch
+                    checked={semanticSearchEnabled}
+                    onChange={(e) => handleToggleSemanticSearch(e.target.checked)}
+                    aria-label="Toggle semantic image search"
+                  />
+                </label>
+                <p className="text-text-muted text-xs">
+                  Downloads a ~400MB model on first use and runs it locally. Embeddings are computed
+                  in the background while you wait for generations and let you search by image
+                  content as well as prompt text. All processing stays in your browser.
+                </p>
+                {semanticSearchEnabled && <SemanticSearchStatus />}
+              </div>
 
-            <div className="border-border-subtle bg-surface-raised/60 space-y-3 rounded-lg border p-3">
-              <div className="flex items-center gap-2">
-                <Bell className="text-accent-muted h-4 w-4" />
-                <span className="text-text-secondary text-sm font-medium">
-                  Desktop notifications
-                </span>
-                {desktopNotificationsEnabled && notificationPermission === "granted" && (
-                  <Check className="h-4 w-4 text-green-500" />
+              <div className="space-y-3 p-3">
+                <label className="flex items-center justify-between gap-3">
+                  <span className="text-text-secondary text-sm">
+                    Notify when generations complete in background
+                  </span>
+                  <Switch
+                    checked={desktopNotificationsEnabled && notificationPermission === "granted"}
+                    disabled={notificationPermission !== "granted"}
+                    onChange={(e) => setDesktopNotificationsEnabled(e.target.checked)}
+                    aria-label="Toggle desktop notifications"
+                  />
+                </label>
+                <p className="text-text-muted text-xs">
+                  {notificationPermission === "unsupported"
+                    ? "Desktop notifications are not supported in this browser."
+                    : notificationPermission === "granted"
+                      ? "Permission granted. You can toggle notifications on or off."
+                      : notificationPermission === "denied"
+                        ? "Permission is blocked. Enable notifications for this site in your browser settings."
+                        : "Grant permission to enable completion notifications."}
+                </p>
+                {notificationPermission === "default" && (
+                  <button
+                    type="button"
+                    onClick={requestNotificationPermission}
+                    disabled={requestingPermission}
+                    className="bg-surface-overlay text-text-secondary hover:bg-surface-interactive rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {requestingPermission ? "Requesting..." : "Request permission"}
+                  </button>
                 )}
               </div>
-              <label className="flex items-center justify-between gap-3">
-                <span className="text-text-secondary text-sm">
-                  Notify when generations complete in background
-                </span>
-                <Switch
-                  checked={desktopNotificationsEnabled && notificationPermission === "granted"}
-                  disabled={notificationPermission !== "granted"}
-                  onChange={(e) => setDesktopNotificationsEnabled(e.target.checked)}
-                  aria-label="Toggle desktop notifications"
-                />
-              </label>
-              <p className="text-text-muted text-xs">
-                {notificationPermission === "unsupported"
-                  ? "Desktop notifications are not supported in this browser."
-                  : notificationPermission === "granted"
-                    ? "Permission granted. You can toggle notifications on or off."
-                    : notificationPermission === "denied"
-                      ? "Permission is blocked. Enable notifications for this site in your browser settings."
-                      : "Grant permission to enable completion notifications."}
-              </p>
-              {notificationPermission === "default" && (
-                <button
-                  type="button"
-                  onClick={requestNotificationPermission}
-                  disabled={requestingPermission}
-                  className="bg-surface-overlay text-text-secondary hover:bg-surface-interactive rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {requestingPermission ? "Requesting..." : "Request permission"}
-                </button>
-              )}
             </div>
           </div>
         </section>

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -3,7 +3,6 @@ import {
   Eye,
   EyeOff,
   Check,
-  ChevronDown,
   Loader2,
   Bell,
   MessageSquareText,
@@ -11,8 +10,15 @@ import {
   Download,
   Upload,
   Sparkles,
+  Layers,
+  Users,
+  Palette,
+  Expand,
+  Image,
+  Plus,
 } from "lucide-react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Link } from "react-router";
 import { GalleryHeader } from "~/components/gallery/GalleryHeader";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { useGalleryStore } from "~/stores/galleryStore";
@@ -23,6 +29,30 @@ import { useEmbeddingStatusStore } from "~/stores/embeddingStatusStore";
 import type { ApiKeyProvider } from "~/types";
 import { Switch } from "~/components/ui/Switch";
 import { SemanticSearchStatus } from "./SemanticSearchStatus";
+import { hasProviderAccess } from "~/lib/providers";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from "@dnd-kit/sortable";
+import SortableModelItem from "./SortableModelItem";
+import SortableStyleItem from "./SortableStyleItem";
+import SortableCharacterItem from "./SortableCharacterItem";
+import SortableUpscalerItem from "./SortableUpscalerItem";
+import TextModelItem from "./TextModelItem";
+import AddCustomModelButton from "./AddCustomModelButton";
+import AddCustomStyleButton from "./AddCustomStyleButton";
+import AddCustomTextModelButton from "./AddCustomTextModelButton";
+import AddCustomUpscalerButton from "./AddCustomUpscalerButton";
 
 const providers: { id: ApiKeyProvider; name: string; description: string; link: string }[] = [
   {
@@ -47,6 +77,11 @@ const providers: { id: ApiKeyProvider; name: string; description: string; link: 
 
 export function SettingsModal() {
   const apiKeys = useSettingsStore((s) => s.apiKeys);
+  const models = useSettingsStore((s) => s.models);
+  const textModels = useSettingsStore((s) => s.textModels);
+  const upscalers = useSettingsStore((s) => s.upscalers);
+  const styles = useSettingsStore((s) => s.styles);
+  const characters = useSettingsStore((s) => s.characters);
   const desktopNotificationsEnabled = useSettingsStore((s) => s.desktopNotificationsEnabled);
   const setApiKey = useSettingsStore((s) => s.setApiKey);
   const editorContextInjectionEnabled = useSettingsStore((s) => s.editorContextInjectionEnabled);
@@ -58,19 +93,20 @@ export function SettingsModal() {
   );
   const setAlwaysImprovePromptEnabled = useSettingsStore((s) => s.setAlwaysImprovePromptEnabled);
   const setSemanticSearchEnabled = useSettingsStore((s) => s.setSemanticSearchEnabled);
+  const reorderModels = useSettingsStore((s) => s.reorderModels);
+  const reorderUpscalers = useSettingsStore((s) => s.reorderUpscalers);
+  const reorderStyles = useSettingsStore((s) => s.reorderStyles);
+  const reorderCharacters = useSettingsStore((s) => s.reorderCharacters);
   const semanticModelId = useEmbeddingStatusStore((s) => s.modelId);
 
   const handleToggleSemanticSearch = (enabled: boolean) => {
     setSemanticSearchEnabled(enabled);
     if (enabled) {
-      // Kick off model preload + backfill of any missing embeddings.
       enqueueMissingEmbeddings(semanticModelId);
       refreshEmbeddingCounts(semanticModelId);
     }
   };
 
-  const apiKeysDetailsRef = useRef<HTMLDetailsElement | null>(null);
-  const desktopNotificationsDetailsRef = useRef<HTMLDetailsElement | null>(null);
   const [requestingPermission, setRequestingPermission] = useState(false);
   const [notificationPermission, setNotificationPermission] = useState<
     NotificationPermission | "unsupported"
@@ -78,20 +114,14 @@ export function SettingsModal() {
     if (typeof window === "undefined" || !("Notification" in window)) {
       return "unsupported";
     }
-
     return Notification.permission;
   });
 
   useEffect(() => {
     if (notificationPermission === "unsupported") return;
-
-    const syncPermission = () => {
-      setNotificationPermission(Notification.permission);
-    };
-
+    const syncPermission = () => setNotificationPermission(Notification.permission);
     window.addEventListener("focus", syncPermission);
     document.addEventListener("visibilitychange", syncPermission);
-
     return () => {
       window.removeEventListener("focus", syncPermission);
       document.removeEventListener("visibilitychange", syncPermission);
@@ -105,43 +135,69 @@ export function SettingsModal() {
   }, [notificationPermission, desktopNotificationsEnabled, setDesktopNotificationsEnabled]);
 
   const requestNotificationPermission = async () => {
-    if (typeof window === "undefined" || !("Notification" in window)) {
-      return;
-    }
-
+    if (typeof window === "undefined" || !("Notification" in window)) return;
     setRequestingPermission(true);
     try {
       const nextPermission = await Notification.requestPermission();
       setNotificationPermission(nextPermission);
-
-      if (nextPermission === "granted") {
-        setDesktopNotificationsEnabled(true);
-      }
-
-      if (nextPermission === "denied") {
-        setDesktopNotificationsEnabled(false);
-      }
+      if (nextPermission === "granted") setDesktopNotificationsEnabled(true);
+      if (nextPermission === "denied") setDesktopNotificationsEnabled(false);
     } finally {
       setRequestingPermission(false);
     }
   };
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleModelDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (over && active.id !== over.id) reorderModels(active.id as string, over.id as string);
+    },
+    [reorderModels]
+  );
+
+  const handleUpscalerDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (over && active.id !== over.id) reorderUpscalers(active.id as string, over.id as string);
+    },
+    [reorderUpscalers]
+  );
+
+  const handleStyleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (over && active.id !== over.id) reorderStyles(active.id as string, over.id as string);
+    },
+    [reorderStyles]
+  );
+
+  const handleCharacterDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (over && active.id !== over.id)
+        reorderCharacters(active.id as string, over.id as string);
+    },
+    [reorderCharacters]
+  );
+
   return (
     <main className="bg-surface flex h-full flex-1 flex-col overflow-hidden">
       <GalleryHeader title="Settings" />
 
-      {/* Content */}
       <div className="flex-1 space-y-6 overflow-y-auto p-4">
-        {/* API Keys Section */}
-        <section className="group space-y-3">
-          <div className="flex w-full items-center justify-between text-left">
-            <div className="flex items-center gap-2">
-              <KeyRound className="text-accent-muted h-4 w-4" />
-              <span className="text-sm font-medium">API Keys</span>
-              {apiKeys.google && apiKeys.replicate && apiKeys.openai && (
-                <Check className="h-4 w-4 text-green-500" />
-              )}
-            </div>
+        {/* API Keys */}
+        <section id="api-keys" className="group space-y-3">
+          <div className="flex items-center gap-2">
+            <KeyRound className="text-accent-muted h-4 w-4" />
+            <span className="text-sm font-medium">API Keys</span>
+            {apiKeys.google && apiKeys.replicate && apiKeys.openai && (
+              <Check className="h-4 w-4 text-green-500" />
+            )}
           </div>
 
           <div className="space-y-3 pl-6">
@@ -160,102 +216,120 @@ export function SettingsModal() {
           </div>
         </section>
 
-        {/* Desktop Notifications Section */}
-        <section className="group space-y-3">
-          <div className="flex w-full items-center justify-between text-left">
-            <div className="flex items-center gap-2">
-              <Bell className="text-accent-muted h-4 w-4" />
-              <span className="text-sm font-medium">Desktop notifications</span>
-              {desktopNotificationsEnabled && notificationPermission === "granted" && (
-                <Check className="h-4 w-4 text-green-500" />
-              )}
-            </div>
+        {/* Image Models */}
+        <section id="image-models" className="group space-y-3">
+          <div className="flex items-center gap-2">
+            <Layers className="text-accent-muted h-4 w-4" />
+            <span className="text-sm font-medium">Image models</span>
           </div>
 
-          <div className="border-border-subtle bg-surface-raised/60 ml-6 space-y-3 rounded-lg border p-3">
-            <label className="flex items-center justify-between gap-3">
-              <span className="text-text-secondary text-sm">
-                Notify when generations complete in background
-              </span>
-              <Switch
-                checked={desktopNotificationsEnabled && notificationPermission === "granted"}
-                disabled={notificationPermission !== "granted"}
-                onChange={(e) => setDesktopNotificationsEnabled(e.target.checked)}
-                aria-label="Toggle desktop notifications"
-              />
-            </label>
-
-            <p className="text-text-muted text-xs">
-              {notificationPermission === "unsupported"
-                ? "Desktop notifications are not supported in this browser."
-                : notificationPermission === "granted"
-                  ? "Permission granted. You can toggle notifications on or off."
-                  : notificationPermission === "denied"
-                    ? "Permission is blocked. Enable notifications for this site in your browser settings."
-                    : "Grant permission to enable completion notifications."}
-            </p>
-
-            {notificationPermission === "default" && (
-              <button
-                type="button"
-                onClick={requestNotificationPermission}
-                disabled={requestingPermission}
-                className="bg-surface-overlay text-text-secondary hover:bg-surface-interactive rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          <div className="space-y-1 pl-6">
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleModelDragEnd}
+            >
+              <SortableContext
+                items={models.map((m) => m.id)}
+                strategy={verticalListSortingStrategy}
               >
-                {requestingPermission ? "Requesting..." : "Request permission"}
-              </button>
-            )}
+                <div className="space-y-1">
+                  {models.map((model) => (
+                    <SortableModelItem
+                      key={model.id}
+                      model={model}
+                      hasApiKey={hasProviderAccess(apiKeys, model.provider)}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+            <AddCustomModelButton />
           </div>
         </section>
 
-        {/* Semantic Search Section */}
-        <section className="group space-y-3">
-          <div className="flex w-full items-center justify-between text-left">
-            <div className="flex items-center gap-2">
-              <Sparkles className="text-accent-muted h-4 w-4" />
-              <span className="text-sm font-medium">Semantic image search</span>
-              {semanticSearchEnabled && <Check className="h-4 w-4 text-green-500" />}
-            </div>
+        {/* Characters */}
+        <section id="characters" className="group space-y-3">
+          <div className="flex items-center gap-2">
+            <Users className="text-accent-muted h-4 w-4" />
+            <span className="text-sm font-medium">Characters</span>
           </div>
 
-          <div className="border-border-subtle bg-surface-raised/60 ml-6 space-y-3 rounded-lg border p-3">
-            <label className="flex items-center justify-between gap-3">
-              <span className="text-text-secondary text-sm">Enable semantic image search</span>
-              <Switch
-                checked={semanticSearchEnabled}
-                onChange={(e) => handleToggleSemanticSearch(e.target.checked)}
-                aria-label="Toggle semantic image search"
-              />
-            </label>
-
-            <p className="text-text-muted text-xs">
-              Downloads a ~400MB model on first use and runs it locally. Embeddings are computed in
-              the background while you wait for generations and let you search by image content as
-              well as prompt text. All processing stays in your browser.
-            </p>
-
-            {semanticSearchEnabled && <SemanticSearchStatus />}
+          <div className="space-y-1 pl-6">
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleCharacterDragEnd}
+            >
+              <SortableContext
+                items={characters.map((c) => c.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-1">
+                  {characters.map((character) => (
+                    <SortableCharacterItem key={character.id} character={character} />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+            <Link
+              to="/app/characters/new"
+              className="border-c-border text-text-tertiary hover:border-c-border hover:text-text-secondary flex w-full items-center gap-2 rounded-lg border border-dashed p-2.5 transition-colors"
+            >
+              <Plus className="h-4 w-4" />
+              <span className="text-sm">Add character</span>
+            </Link>
           </div>
         </section>
 
-        {/* Text Generation Section */}
-        <section className="group space-y-3">
-          <div className="flex w-full items-center justify-between text-left">
-            <div className="flex items-center gap-2">
-              <MessageSquareText className="text-accent-muted h-4 w-4" />
-              <span className="text-sm font-medium">Text generation</span>
-              {(apiKeys.google || apiKeys.replicate || apiKeys.openai) && (
-                <Check className="h-4 w-4 text-green-500" />
-              )}
-            </div>
+        {/* Styles */}
+        <section id="styles" className="group space-y-3">
+          <div className="flex items-center gap-2">
+            <Palette className="text-accent-muted h-4 w-4" />
+            <span className="text-sm font-medium">Styles</span>
           </div>
 
-          <div className="border-border-subtle bg-surface-raised/60 ml-6 space-y-3 rounded-lg border p-3">
-            <p className="text-text-muted text-xs">
-              The active text model is chosen in the sidebar. These settings control how it's used.
-            </p>
+          <div className="space-y-1 pl-6">
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleStyleDragEnd}
+            >
+              <SortableContext
+                items={styles.map((s) => s.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-1">
+                  {styles.map((style) => (
+                    <SortableStyleItem key={style.id} style={style} />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+            <AddCustomStyleButton />
+          </div>
+        </section>
 
-            <div className="space-y-3">
+        {/* Text Models */}
+        <section id="text-models" className="group space-y-3">
+          <div className="flex items-center gap-2">
+            <MessageSquareText className="text-accent-muted h-4 w-4" />
+            <span className="text-sm font-medium">Text models</span>
+          </div>
+
+          <div className="space-y-3 pl-6">
+            <div className="space-y-1">
+              {textModels.map((model) => (
+                <TextModelItem
+                  key={model.id}
+                  model={model}
+                  hasApiKey={hasProviderAccess(apiKeys, model.provider)}
+                />
+              ))}
+            </div>
+            <AddCustomTextModelButton />
+
+            <div className="border-border-subtle bg-surface-raised/60 space-y-3 rounded-lg border p-3">
               <label className="flex items-center justify-between gap-3">
                 <span className="text-text-secondary text-sm">Always rewrite prompt</span>
                 <Switch
@@ -271,8 +345,111 @@ export function SettingsModal() {
                 in the lightbox.
               </p>
             </div>
+          </div>
+        </section>
 
-            <div className="border-border-subtle space-y-3 border-t pt-3">
+        {/* Gallery */}
+        <section id="gallery" className="group space-y-3">
+          <div className="flex items-center gap-2">
+            <Image className="text-accent-muted h-4 w-4" />
+            <span className="text-sm font-medium">Gallery</span>
+          </div>
+
+          <div className="space-y-3 pl-6">
+            <div className="border-border-subtle bg-surface-raised/60 space-y-3 rounded-lg border p-3">
+              <label className="flex items-center justify-between gap-3">
+                <span className="text-text-secondary text-sm">Enable semantic image search</span>
+                <Switch
+                  checked={semanticSearchEnabled}
+                  onChange={(e) => handleToggleSemanticSearch(e.target.checked)}
+                  aria-label="Toggle semantic image search"
+                />
+              </label>
+              <p className="text-text-muted text-xs">
+                Downloads a ~400MB model on first use and runs it locally. Embeddings are computed
+                in the background while you wait for generations and let you search by image content
+                as well as prompt text. All processing stays in your browser.
+              </p>
+              {semanticSearchEnabled && <SemanticSearchStatus />}
+            </div>
+
+            <div className="border-border-subtle bg-surface-raised/60 space-y-3 rounded-lg border p-3">
+              <div className="flex items-center gap-2">
+                <Bell className="text-accent-muted h-4 w-4" />
+                <span className="text-text-secondary text-sm font-medium">
+                  Desktop notifications
+                </span>
+                {desktopNotificationsEnabled && notificationPermission === "granted" && (
+                  <Check className="h-4 w-4 text-green-500" />
+                )}
+              </div>
+              <label className="flex items-center justify-between gap-3">
+                <span className="text-text-secondary text-sm">
+                  Notify when generations complete in background
+                </span>
+                <Switch
+                  checked={desktopNotificationsEnabled && notificationPermission === "granted"}
+                  disabled={notificationPermission !== "granted"}
+                  onChange={(e) => setDesktopNotificationsEnabled(e.target.checked)}
+                  aria-label="Toggle desktop notifications"
+                />
+              </label>
+              <p className="text-text-muted text-xs">
+                {notificationPermission === "unsupported"
+                  ? "Desktop notifications are not supported in this browser."
+                  : notificationPermission === "granted"
+                    ? "Permission granted. You can toggle notifications on or off."
+                    : notificationPermission === "denied"
+                      ? "Permission is blocked. Enable notifications for this site in your browser settings."
+                      : "Grant permission to enable completion notifications."}
+              </p>
+              {notificationPermission === "default" && (
+                <button
+                  type="button"
+                  onClick={requestNotificationPermission}
+                  disabled={requestingPermission}
+                  className="bg-surface-overlay text-text-secondary hover:bg-surface-interactive rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {requestingPermission ? "Requesting..." : "Request permission"}
+                </button>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* Editor */}
+        <section id="editor" className="group space-y-3">
+          <div className="flex items-center gap-2">
+            <Expand className="text-accent-muted h-4 w-4" />
+            <span className="text-sm font-medium">Editor</span>
+          </div>
+
+          <div className="space-y-3 pl-6">
+            <div className="space-y-1">
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleUpscalerDragEnd}
+              >
+                <SortableContext
+                  items={upscalers.map((u) => u.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-1">
+                    {upscalers.map((u) => (
+                      <SortableUpscalerItem
+                        key={u.id}
+                        upscaler={u}
+                        hasApiKey={!!apiKeys.replicate}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+              <AddCustomUpscalerButton />
+            </div>
+
+            <div className="border-border-subtle bg-surface-raised/60 space-y-3 rounded-lg border p-3">
               <label className="flex items-center justify-between gap-3">
                 <span className="text-text-secondary text-sm">Editor context briefs</span>
                 <Switch
@@ -290,7 +467,7 @@ export function SettingsModal() {
           </div>
         </section>
 
-        {/* Data Section */}
+        {/* Data */}
         <DataSection />
       </div>
     </main>
@@ -350,12 +527,10 @@ function DataSection() {
   };
 
   return (
-    <section className="group space-y-3">
-      <div className="flex w-full items-center justify-between text-left">
-        <div className="flex items-center gap-2">
-          <Archive className="text-accent-muted h-4 w-4" />
-          <span className="text-sm font-medium">Data</span>
-        </div>
+    <section id="data" className="group space-y-3">
+      <div className="flex items-center gap-2">
+        <Archive className="text-accent-muted h-4 w-4" />
+        <span className="text-sm font-medium">Data</span>
       </div>
 
       <div className="border-border-subtle bg-surface-raised/60 ml-6 space-y-3 rounded-lg border p-3">

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   X,
 } from "lucide-react";
 import { useLocation } from "react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { PromptInput } from "./PromptInput";
 import { ModelList } from "./ModelList";
 import { UpscalerList } from "./UpscalerList";

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -146,12 +146,12 @@ function SettingsSidebarContent() {
   };
 
   return (
-    <nav className="flex-1 flex flex-col justify-center bg-surface px-3 py-4 gap-0.5">
+    <nav className="bg-surface flex flex-1 flex-col justify-center gap-0.5 px-3 py-4">
       {SETTINGS_TOC.map(({ id, label, Icon }) => (
         <button
           key={id}
           onClick={() => scrollTo(id)}
-          className={`flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm transition-colors text-left ${
+          className={`flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left text-sm transition-colors ${
             activeId === id
               ? "bg-surface-overlay text-text-primary"
               : "text-text-secondary hover:bg-surface-overlay"

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   X,
 } from "lucide-react";
 import { useLocation } from "react-router";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { PromptInput } from "./PromptInput";
 import { ModelList } from "./ModelList";
 import { UpscalerList } from "./UpscalerList";
@@ -23,7 +24,6 @@ import { AvoidPastVariationsToggle } from "./AvoidPastVariationsToggle";
 import SVG from "react-inlinesvg";
 import drop from "~/drop.svg";
 import { useEditorStore } from "~/stores/editorStore";
-import { useCallback, useEffect, useState } from "react";
 import { Accordion } from "@base-ui/react/accordion";
 import { RecentSessions } from "./RecentSessions";
 
@@ -111,19 +111,55 @@ function EditorSidebarContent() {
 }
 
 function SettingsSidebarContent() {
+  const [activeId, setActiveId] = useState<string>(SETTINGS_TOC[0].id);
+  const intersectingRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const scrollRoot = document.getElementById("settings-scroll");
+    const sectionIds = SETTINGS_TOC.map((s) => s.id);
+
+    const updateActive = () => {
+      const first = sectionIds.find((id) => intersectingRef.current.has(id));
+      if (first) setActiveId(first);
+    };
+
+    const observers = sectionIds.map((id) => {
+      const el = document.getElementById(id);
+      if (!el) return null;
+      const obs = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) intersectingRef.current.add(id);
+          else intersectingRef.current.delete(id);
+          updateActive();
+        },
+        { root: scrollRoot, rootMargin: "0px 0px -60% 0px", threshold: 0 }
+      );
+      obs.observe(el);
+      return obs;
+    });
+
+    return () => observers.forEach((o) => o?.disconnect());
+  }, []);
+
   const scrollTo = (id: string) => {
     document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
   };
 
   return (
-    <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-0.5">
+    <nav className="flex-1 flex flex-col justify-center bg-surface px-3 py-4 gap-0.5">
       {SETTINGS_TOC.map(({ id, label, Icon }) => (
         <button
           key={id}
           onClick={() => scrollTo(id)}
-          className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm text-text-secondary hover:bg-surface-overlay transition-colors text-left"
+          className={`flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm transition-colors text-left ${
+            activeId === id
+              ? "bg-surface-overlay text-text-primary"
+              : "text-text-secondary hover:bg-surface-overlay"
+          }`}
         >
-          <Icon className="h-4 w-4 text-text-muted shrink-0" />
+          <Icon
+            className={`h-4 w-4 shrink-0 ${activeId === id ? "text-accent" : "text-text-muted"}`}
+          />
           {label}
         </button>
       ))}

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -1,4 +1,14 @@
-import { Expand, Layers, MessageSquareText, Palette, Plus, Users, X } from "lucide-react";
+import {
+  Archive,
+  Expand,
+  Image,
+  KeyRound,
+  Layers,
+  MessageSquareText,
+  Palette,
+  Users,
+  X,
+} from "lucide-react";
 import { useLocation } from "react-router";
 import { PromptInput } from "./PromptInput";
 import { ModelList } from "./ModelList";
@@ -12,38 +22,23 @@ import { PromptVariationsToggle } from "./PromptVariationsToggle";
 import { AvoidPastVariationsToggle } from "./AvoidPastVariationsToggle";
 import SVG from "react-inlinesvg";
 import drop from "~/drop.svg";
-import AddCustomModelButton from "../settings/AddCustomModelButton";
-import AddCustomStyleButton from "../settings/AddCustomStyleButton";
-import AddCustomTextModelButton from "../settings/AddCustomTextModelButton";
-import AddCustomUpscalerButton from "../settings/AddCustomUpscalerButton";
-import SortableModelItem from "../settings/SortableModelItem";
-import SortableStyleItem from "../settings/SortableStyleItem";
-import SortableCharacterItem from "../settings/SortableCharacterItem";
-import SortableUpscalerItem from "../settings/SortableUpscalerItem";
-import TextModelItem from "../settings/TextModelItem";
-import { Link } from "react-router";
-import { hasProviderAccess } from "~/lib/providers";
-import { useSettingsStore } from "~/stores/settingsStore";
 import { useEditorStore } from "~/stores/editorStore";
 import { useCallback, useEffect, useState } from "react";
 import { Accordion } from "@base-ui/react/accordion";
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-  sortableKeyboardCoordinates,
-} from "@dnd-kit/sortable";
 import { RecentSessions } from "./RecentSessions";
 
 export const SIDEBAR_POPOVER_ID = "sidebar-popover";
+
+const SETTINGS_TOC = [
+  { id: "api-keys", label: "API Keys", Icon: KeyRound },
+  { id: "image-models", label: "Image models", Icon: Layers },
+  { id: "characters", label: "Characters", Icon: Users },
+  { id: "styles", label: "Styles", Icon: Palette },
+  { id: "text-models", label: "Text models", Icon: MessageSquareText },
+  { id: "gallery", label: "Gallery", Icon: Image },
+  { id: "editor", label: "Editor", Icon: Expand },
+  { id: "data", label: "Data", Icon: Archive },
+] as const;
 
 function SidebarContent() {
   const location = useLocation();
@@ -116,197 +111,23 @@ function EditorSidebarContent() {
 }
 
 function SettingsSidebarContent() {
-  const models = useSettingsStore((s) => s.models);
-  const textModels = useSettingsStore((s) => s.textModels);
-  const upscalers = useSettingsStore((s) => s.upscalers);
-  const styles = useSettingsStore((s) => s.styles);
-  const characters = useSettingsStore((s) => s.characters);
-  const apiKeys = useSettingsStore((s) => s.apiKeys);
-  const reorderModels = useSettingsStore((s) => s.reorderModels);
-  const reorderUpscalers = useSettingsStore((s) => s.reorderUpscalers);
-  const reorderStyles = useSettingsStore((s) => s.reorderStyles);
-  const reorderCharacters = useSettingsStore((s) => s.reorderCharacters);
-  const location = useLocation();
-
-  useEffect(() => {
-    if (location.hash === "#characters") {
-      const el = document.getElementById("characters");
-      if (el) el.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [location.hash]);
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  );
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (over && active.id !== over.id) {
-        reorderModels(active.id as string, over.id as string);
-      }
-    },
-    [reorderModels]
-  );
-
-  const handleUpscalerDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (over && active.id !== over.id) {
-        reorderUpscalers(active.id as string, over.id as string);
-      }
-    },
-    [reorderUpscalers]
-  );
-
-  const handleStyleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (over && active.id !== over.id) {
-        reorderStyles(active.id as string, over.id as string);
-      }
-    },
-    [reorderStyles]
-  );
-
-  const handleCharacterDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (over && active.id !== over.id) {
-        reorderCharacters(active.id as string, over.id as string);
-      }
-    },
-    [reorderCharacters]
-  );
+  const scrollTo = (id: string) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+  };
 
   return (
-    <div className="flex-1 space-y-2 overflow-y-auto px-3 py-4 [scrollbar-gutter:stable_both-edges]">
-      <div className="flex items-center gap-2">
-        <span className="text-text-muted">
-          <Layers className="h-4 w-4" />
-        </span>
-        <h2 className="text-text-tertiary text-xs font-medium tracking-wide uppercase">
-          Image Models
-        </h2>
-      </div>
-
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={models.map((m) => m.id)} strategy={verticalListSortingStrategy}>
-          <div className="space-y-1">
-            {models.map((model) => (
-              <SortableModelItem
-                key={model.id}
-                model={model}
-                hasApiKey={hasProviderAccess(apiKeys, model.provider)}
-              />
-            ))}
-          </div>
-        </SortableContext>
-      </DndContext>
-
-      <AddCustomModelButton />
-
-      <div className="flex items-center gap-2 pt-4">
-        <span className="text-text-muted">
-          <MessageSquareText className="h-4 w-4" />
-        </span>
-        <h2 className="text-text-tertiary text-xs font-medium tracking-wide uppercase">
-          Text Model
-        </h2>
-      </div>
-
-      <div className="space-y-1">
-        {textModels.map((model) => (
-          <TextModelItem
-            key={model.id}
-            model={model}
-            hasApiKey={hasProviderAccess(apiKeys, model.provider)}
-          />
-        ))}
-      </div>
-
-      <AddCustomTextModelButton />
-
-      <div className="flex items-center gap-2 pt-4">
-        <span className="text-text-muted">
-          <Expand className="h-4 w-4" />
-        </span>
-        <h2 className="text-text-tertiary text-xs font-medium tracking-wide uppercase">
-          Upscalers
-        </h2>
-      </div>
-
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleUpscalerDragEnd}
-      >
-        <SortableContext items={upscalers.map((u) => u.id)} strategy={verticalListSortingStrategy}>
-          <div className="space-y-1">
-            {upscalers.map((u) => (
-              <SortableUpscalerItem key={u.id} upscaler={u} hasApiKey={!!apiKeys.replicate} />
-            ))}
-          </div>
-        </SortableContext>
-      </DndContext>
-
-      <AddCustomUpscalerButton />
-
-      <div className="flex items-center gap-2 pt-4">
-        <span className="text-text-muted">
-          <Palette className="h-4 w-4" />
-        </span>
-        <h2 className="text-text-tertiary text-xs font-medium tracking-wide uppercase">Styles</h2>
-      </div>
-
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleStyleDragEnd}
-      >
-        <SortableContext items={styles.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-          <div className="space-y-1">
-            {styles.map((style) => (
-              <SortableStyleItem key={style.id} style={style} />
-            ))}
-          </div>
-        </SortableContext>
-      </DndContext>
-
-      <AddCustomStyleButton />
-
-      <div id="characters" className="flex items-center gap-2 pt-4">
-        <span className="text-text-muted">
-          <Users className="h-4 w-4" />
-        </span>
-        <h2 className="text-text-tertiary text-xs font-medium tracking-wide uppercase">
-          Characters
-        </h2>
-      </div>
-
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleCharacterDragEnd}
-      >
-        <SortableContext items={characters.map((c) => c.id)} strategy={verticalListSortingStrategy}>
-          <div className="space-y-1">
-            {characters.map((character) => (
-              <SortableCharacterItem key={character.id} character={character} />
-            ))}
-          </div>
-        </SortableContext>
-      </DndContext>
-
-      <Link
-        to="/app/characters/new"
-        className="border-c-border text-text-tertiary hover:border-c-border hover:text-text-secondary flex w-full items-center gap-2 rounded-lg border border-dashed p-2.5 transition-colors"
-      >
-        <Plus className="h-4 w-4" />
-        <span className="text-sm">Add character</span>
-      </Link>
-    </div>
+    <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-0.5">
+      {SETTINGS_TOC.map(({ id, label, Icon }) => (
+        <button
+          key={id}
+          onClick={() => scrollTo(id)}
+          className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm text-text-secondary hover:bg-surface-overlay transition-colors text-left"
+        >
+          <Icon className="h-4 w-4 text-text-muted shrink-0" />
+          {label}
+        </button>
+      ))}
+    </nav>
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #61

Redesigns the settings page to fix overflow and cramped layout issues in the sidebar:

- **Sidebar becomes a table of contents**: replaces the full model/style/character lists with an icon + label nav that scrolls the main content to each section. Active section is highlighted using an `IntersectionObserver` scroll-spy.
- **Settings content moves to the main panel**: all config controls now live in a unified scrollable page with named section anchors (`id="api-keys"`, `"image-models"`, etc.).
- **New section order** per issue: API Keys → Image Models → Characters → Styles → Text Models → Gallery → Editor → Data.
- **Settings relocated**: "Always rewrite prompt" moved under Text Models; "Semantic image search" moved under Gallery; "Editor context briefs" and upscale models moved under Editor.
- DnD reorder handlers (models, styles, characters, upscalers) moved from `Sidebar.tsx` into `Settings.tsx` where they now render.

## Validation steps

- [ ] Navigate to `/app/settings` — sidebar shows 8 TOC entries (API Keys through Data)
- [ ] Click a TOC entry — main panel smooth-scrolls to that section
- [ ] Scroll the main panel manually — active TOC entry updates to reflect current position
- [ ] Drag to reorder image models / styles / characters / upscalers — order persists after reload
- [ ] Toggle "Always rewrite prompt", "Semantic image search", "Editor context briefs" — state persists
- [ ] Notifications permission flow still works in the Gallery section
- [ ] Export/import in Data section still works
- [ ] Sidebar on gallery and editor pages is unchanged