### PR TITLE
feat: replace model count stepper with radio button in character sidebar

### DIFF
--- a/app/components/character/CharacterEditView.tsx
+++ b/app/components/character/CharacterEditView.tsx
@@ -224,8 +224,8 @@ function ModelWarningBanner() {
     <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-200">
       <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-yellow-300" />
       <p>
-        Select an image model in the sidebar to generate a reference. Open the sidebar on the left
-        and toggle a model under <span className="font-medium">Models</span>.
+        No image model is available. Add an API key and enable at least one model in{" "}
+        <span className="font-medium">Settings</span>.
       </p>
     </div>
   );

--- a/app/components/character/CharacterEditView.tsx
+++ b/app/components/character/CharacterEditView.tsx
@@ -483,7 +483,7 @@ export function CharacterEditView() {
       return;
     }
     if (!hasImageModelSelected) {
-      setError("Select an image model in the sidebar first");
+      setError("No image model selected. Add an API key and enable a model in Settings.");
       return;
     }
 
@@ -518,7 +518,7 @@ export function CharacterEditView() {
       return;
     }
     if (!hasImageModelSelected) {
-      setError("Select an image model in the sidebar first");
+      setError("No image model selected. Add an API key and enable a model in Settings.");
       return;
     }
 

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -501,9 +501,13 @@ function DataSection() {
       if (result.referencesImported > 0)
         parts.push(`${result.referencesImported} references imported`);
       if (result.charactersImported > 0)
-        parts.push(`${result.charactersImported} character${result.charactersImported !== 1 ? "s" : ""} imported`);
+        parts.push(
+          `${result.charactersImported} character${result.charactersImported !== 1 ? "s" : ""} imported`
+        );
       if (result.stylesImported > 0)
-        parts.push(`${result.stylesImported} custom style${result.stylesImported !== 1 ? "s" : ""} imported`);
+        parts.push(
+          `${result.stylesImported} custom style${result.stylesImported !== 1 ? "s" : ""} imported`
+        );
       if (result.skipped > 0) parts.push(`${result.skipped} skipped (already exist)`);
       if (result.failed > 0) parts.push(`${result.failed} failed`);
       setStatus(parts.join(", "));

--- a/app/components/sidebar/CharacterModelItem.tsx
+++ b/app/components/sidebar/CharacterModelItem.tsx
@@ -1,0 +1,52 @@
+import { Box, Check } from "lucide-react";
+import SVG from "react-inlinesvg";
+import type { StoredModel } from "~/types";
+import { PROVIDERS } from "~/lib/providers";
+
+interface CharacterModelItemProps {
+  model: StoredModel;
+  isSelected: boolean;
+  onSelect: () => void;
+}
+
+export function CharacterModelItem({ model, isSelected, onSelect }: CharacterModelItemProps) {
+  const provider = PROVIDERS[model.provider];
+
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      onClick={onSelect}
+      className={`flex w-full items-center gap-2 rounded-lg border p-2.5 text-left transition-colors ${
+        isSelected
+          ? "border-purple-600/50 bg-purple-900/20"
+          : "border-c-border/50 bg-surface-overlay/50 hover:bg-surface-overlay"
+      }`}
+    >
+      <div
+        className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
+          isSelected
+            ? "text-accent-muted bg-purple-500/20"
+            : "bg-surface-interactive text-text-tertiary"
+        }`}
+      >
+        {model.icon ? <SVG src={model.icon} className="h-5 w-5" /> : <Box className="h-4 w-4" />}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-text-primary truncate text-sm font-medium">{model.name}</p>
+        <p className="text-text-muted truncate text-xs">{provider.label}</p>
+      </div>
+
+      <div
+        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
+          isSelected ? "border-purple-500 bg-purple-500 text-white" : "border-c-border"
+        }`}
+        aria-hidden="true"
+      >
+        {isSelected && <Check className="h-3 w-3" strokeWidth={3} />}
+      </div>
+    </button>
+  );
+}

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -21,9 +21,13 @@ import { NumberOfImagesSection } from "./NumberOfImagesSection";
 import { GenerateButton } from "./GenerateButton";
 import { PromptVariationsToggle } from "./PromptVariationsToggle";
 import { AvoidPastVariationsToggle } from "./AvoidPastVariationsToggle";
+import { CharacterModelItem } from "./CharacterModelItem";
 import SVG from "react-inlinesvg";
 import drop from "~/drop.svg";
 import { useEditorStore } from "~/stores/editorStore";
+import { useGenerationStore } from "~/stores/generationStore";
+import { useSettingsStore } from "~/stores/settingsStore";
+import { hasProviderAccess } from "~/lib/providers";
 import { Accordion } from "@base-ui/react/accordion";
 import { RecentSessions } from "./RecentSessions";
 
@@ -40,6 +44,50 @@ const SETTINGS_TOC = [
   { id: "data", label: "Data", Icon: Archive },
 ] as const;
 
+function CharacterSidebarContent() {
+  const models = useSettingsStore((s) => s.models);
+  const apiKeys = useSettingsStore((s) => s.apiKeys);
+  const modelSelections = useGenerationStore((s) => s.currentModelSelections);
+  const setModelCount = useGenerationStore((s) => s.setModelCount);
+
+  const visibleModels = models.filter((m) => m.enabled && hasProviderAccess(apiKeys, m.provider));
+
+  useEffect(() => {
+    if (visibleModels.length === 0) return;
+    const alreadySelected = visibleModels.find((m) => (modelSelections[m.id] ?? 0) > 0);
+    const toSelect = alreadySelected ?? visibleModels[0];
+    visibleModels.forEach((m) => setModelCount(m.id, m.id === toSelect.id ? 1 : 0));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const selectedId = visibleModels.find((m) => (modelSelections[m.id] ?? 0) > 0)?.id ?? null;
+
+  const handleSelect = (modelId: string) => {
+    visibleModels.forEach((m) => setModelCount(m.id, m.id === modelId ? 1 : 0));
+  };
+
+  return (
+    <div className="flex-1 space-y-2 overflow-y-auto px-3 py-4">
+      <p className="text-text-tertiary mb-3 px-1 text-xs font-medium tracking-wide uppercase">
+        Image model
+      </p>
+      {visibleModels.length === 0 ? (
+        <p className="text-text-muted py-4 text-center text-xs">
+          No models available. Add API keys and enable models in Settings.
+        </p>
+      ) : (
+        visibleModels.map((model) => (
+          <CharacterModelItem
+            key={model.id}
+            model={model}
+            isSelected={model.id === selectedId}
+            onSelect={() => handleSelect(model.id)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
 function SidebarContent() {
   const location = useLocation();
 
@@ -47,6 +95,8 @@ function SidebarContent() {
     return <SettingsSidebarContent />;
   } else if (location.pathname.startsWith("/app/editor")) {
     return <EditorSidebarContent />;
+  } else if (location.pathname.startsWith("/app/characters")) {
+    return <CharacterSidebarContent />;
   } else {
     return <GallerySidebarContent />;
   }

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -66,24 +66,27 @@ function CharacterSidebarContent() {
   };
 
   return (
-    <div className="flex-1 space-y-2 overflow-y-auto px-3 py-4">
-      <p className="text-text-tertiary mb-3 px-1 text-xs font-medium tracking-wide uppercase">
-        Image model
-      </p>
-      {visibleModels.length === 0 ? (
-        <p className="text-text-muted py-4 text-center text-xs">
-          No models available. Add API keys and enable models in Settings.
+    <div className="flex-1 space-y-6 overflow-y-auto px-3 py-4">
+      <div className="space-y-2">
+        <p className="text-text-tertiary mb-3 px-1 text-xs font-medium tracking-wide uppercase">
+          Image model
         </p>
-      ) : (
-        visibleModels.map((model) => (
-          <CharacterModelItem
-            key={model.id}
-            model={model}
-            isSelected={model.id === selectedId}
-            onSelect={() => handleSelect(model.id)}
-          />
-        ))
-      )}
+        {visibleModels.length === 0 ? (
+          <p className="text-text-muted py-4 text-center text-xs">
+            No models available. Add API keys and enable models in Settings.
+          </p>
+        ) : (
+          visibleModels.map((model) => (
+            <CharacterModelItem
+              key={model.id}
+              model={model}
+              isSelected={model.id === selectedId}
+              onSelect={() => handleSelect(model.id)}
+            />
+          ))
+        )}
+      </div>
+      <ResolutionSection />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the count-based model stepper in the character sidebar with a single-select radio button list, matching the existing text model UI pattern in Settings
- Adds `CharacterModelItem` component — a full-width radio button card showing model icon, name, and provider
- `CharacterSidebarContent` initialises selection on mount: preserves any existing selection, otherwise defaults to the first available model
- Updates the `ModelWarningBanner` and two defensive error strings in `CharacterEditView` to reflect that the user should go to **Settings** (not toggle a sidebar count) when no model is available

Closes #62

## Validation

- [ ] Navigate to **Characters → New** — sidebar shows radio list of enabled models; first model is selected by default
- [ ] Select a different model — radio highlight moves, generation uses the newly selected model
- [ ] Remove all API keys in Settings — sidebar shows "No models available" empty state; generate buttons are disabled and `ModelWarningBanner` is shown
- [ ] Navigate away and back to Characters — previous model selection is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)