### PR TITLE
feat: add video model support via Replicate (#57)

### DIFF
--- a/app/components/gallery/ImageCard.tsx
+++ b/app/components/gallery/ImageCard.tsx
@@ -1,4 +1,4 @@
-import { Check, Star } from "lucide-react";
+import { Check, Play, Star } from "lucide-react";
 import { useState, useCallback, type ChangeEvent, type MouseEvent } from "react";
 import { getScorecardAverage } from "~/lib/scorecard";
 import { useGalleryStore } from "~/stores/galleryStore";
@@ -12,6 +12,7 @@ interface ImageCardProps {
 
 export function ImageCard({ image, selectionDisabled = false }: ImageCardProps) {
   const [isLoaded, setIsLoaded] = useState(false);
+  const isVideo = image.originalBlob.type.startsWith("video/");
   const openLightbox = useLightboxStore((s) => s.openLightbox);
   const selectedItemIds = useGalleryStore((s) => s.selectedItemIds);
   const toggleItemSelection = useGalleryStore((s) => s.toggleItemSelection);
@@ -122,6 +123,15 @@ export function ImageCard({ image, selectionDisabled = false }: ImageCardProps) 
             aspectRatio: image.width && image.height ? `${image.width}/${image.height}` : "1/1",
           }}
         />
+      )}
+
+      {/* Video play indicator */}
+      {isVideo && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-black/60 backdrop-blur-sm">
+            <Play className="h-5 w-5 fill-white text-white" />
+          </div>
+        </div>
       )}
 
       {/* Persistent model badge */}

--- a/app/components/lightbox/Lightbox.tsx
+++ b/app/components/lightbox/Lightbox.tsx
@@ -227,8 +227,10 @@ export function Lightbox() {
 
   if (!galleryImage && !referenceImage) return null;
 
-  const imageSrc = galleryImage?.originalUrl ?? referenceImage?.url ?? "";
-  const imageAlt = galleryImage?.prompt ?? referenceImage?.name ?? "Image preview";
+  const mediaSrc = galleryImage?.originalUrl ?? referenceImage?.url ?? "";
+  const mediaAlt = galleryImage?.prompt ?? referenceImage?.name ?? "Image preview";
+  const isVideo =
+    galleryImage?.status === "completed" && galleryImage.originalBlob.type.startsWith("video/");
 
   const topMetadataRow = [
     galleryImage?.aspectRatio,
@@ -275,12 +277,24 @@ export function Lightbox() {
 
       {/* Modal */}
       <div className="animate-fade-in bg-surface-raised relative z-10 flex max-h-[90vh] max-w-[90vw] flex-col overflow-hidden overflow-y-auto rounded-xl shadow-2xl inset-shadow-sm inset-shadow-white/5 lg:flex-row lg:items-stretch">
-        {/* Image */}
-        <img
-          src={imageSrc}
-          alt={imageAlt}
-          className="block min-h-[50vh] min-w-0 self-center object-contain lg:max-h-[90vh] lg:min-h-0 lg:max-w-[calc(90vw-24rem)] xl:max-w-[calc(90vw-28rem)]"
-        />
+        {/* Media (image or video) */}
+        {isVideo ? (
+          <video
+            src={mediaSrc}
+            controls
+            autoPlay
+            loop
+            muted
+            playsInline
+            className="block min-h-[50vh] min-w-0 self-center object-contain lg:max-h-[90vh] lg:min-h-0 lg:max-w-[calc(90vw-24rem)] xl:max-w-[calc(90vw-28rem)]"
+          />
+        ) : (
+          <img
+            src={mediaSrc}
+            alt={mediaAlt}
+            className="block min-h-[50vh] min-w-0 self-center object-contain lg:max-h-[90vh] lg:min-h-0 lg:max-w-[calc(90vw-24rem)] xl:max-w-[calc(90vw-28rem)]"
+          />
+        )}
 
         {/* Info panel */}
         {galleryImage && (
@@ -291,7 +305,7 @@ export function Lightbox() {
                 {galleryImage.modelName}
               </h2>
               <div className="flex items-center gap-1">
-                {location.pathname !== "/app/editor" && (
+                {location.pathname !== "/app/editor" && !isVideo && (
                   <WideIconButton
                     icon={
                       <span className="relative">
@@ -306,7 +320,7 @@ export function Lightbox() {
                     onClick={handleSendToEditor}
                   />
                 )}
-                {location.pathname !== "/app/editor" && (
+                {location.pathname !== "/app/editor" && !isVideo && (
                   <WideIconButton
                     icon={<ImageUpscale className="h-4 w-4" />}
                     title="Upscale"
@@ -489,6 +503,8 @@ export function Lightbox() {
 
 function getBlobExtension(blob: Blob): string {
   const type = blob.type.toLowerCase();
+  if (type.includes("mp4")) return "mp4";
+  if (type.includes("webm")) return "webm";
   if (type.includes("png")) return "png";
   if (type.includes("webp")) return "webp";
   if (type.includes("jpeg") || type.includes("jpg")) return "jpg";

--- a/app/components/settings/ModelToggle.tsx
+++ b/app/components/settings/ModelToggle.tsx
@@ -7,6 +7,7 @@ import {
   RefreshCw,
   GalleryHorizontalEnd,
   Sparkles,
+  Video,
 } from "lucide-react";
 import { useSettingsStore } from "~/stores/settingsStore";
 import SVG from "react-inlinesvg";
@@ -161,6 +162,11 @@ export default function ModelToggleItem({
               <SVG src={provider.iconPath} className="h-2.5 w-2.5 overflow-visible" />
             </span>
           </Tooltip>
+          <CapabilityBadge
+            icon={Video}
+            label="Video output"
+            enabled={capabilities.outputType === "video"}
+          />
           <CapabilityBadge
             icon={RectangleHorizontal}
             label={<AspectRatioTooltipContent model={model} />}

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -501,9 +501,13 @@ function DataSection() {
       if (result.referencesImported > 0)
         parts.push(`${result.referencesImported} references imported`);
       if (result.charactersImported > 0)
-        parts.push(`${result.charactersImported} character${result.charactersImported !== 1 ? "s" : ""} imported`);
+        parts.push(
+          `${result.charactersImported} character${result.charactersImported !== 1 ? "s" : ""} imported`
+        );
       if (result.stylesImported > 0)
-        parts.push(`${result.stylesImported} custom style${result.stylesImported !== 1 ? "s" : ""} imported`);
+        parts.push(
+          `${result.stylesImported} custom style${result.stylesImported !== 1 ? "s" : ""} imported`
+        );
       if (result.skipped > 0) parts.push(`${result.skipped} skipped (already exist)`);
       if (result.failed > 0) parts.push(`${result.failed} failed`);
       setStatus(parts.join(", "));

--- a/app/components/sidebar/ModelItem.tsx
+++ b/app/components/sidebar/ModelItem.tsx
@@ -98,9 +98,16 @@ export function ModelItem({ model, count }: ModelItemProps) {
 
       {/* Info */}
       <div className="min-w-0 flex-1">
-        <p className="text-text-primary truncate text-sm font-medium" title={model.name}>
-          {model.name}
-        </p>
+        <div className="flex items-center gap-1.5">
+          <p className="text-text-primary truncate text-sm font-medium" title={model.name}>
+            {model.name}
+          </p>
+          {model.capabilities.outputType === "video" && (
+            <span className="shrink-0 rounded bg-blue-500/20 px-1 py-0.5 text-[10px] font-medium text-blue-400">
+              Video
+            </span>
+          )}
+        </div>
         <p className="text-text-muted text-xs">{provider.label}</p>
       </div>
 

--- a/app/hooks/useAttachSelectedItemsToGeneration.ts
+++ b/app/hooks/useAttachSelectedItemsToGeneration.ts
@@ -18,12 +18,20 @@ export function useAttachSelectedItemsToGeneration() {
         item.status === "completed" && selectedSet.has(item.id)
     );
 
-    if (selectedItems.length === 0) {
+    // Exclude video items — reference images must be still frames.
+    const imageOnlyItems = selectedItems.filter(
+      (item) => !item.originalBlob.type.startsWith("video/")
+    );
+
+    if (imageOnlyItems.length === 0) {
       return {
         success: false,
         attachedCount: 0,
         maxAllowed: null,
-        reason: "No images selected.",
+        reason:
+          selectedItems.length > 0
+            ? "Videos cannot be used as reference images."
+            : "No images selected.",
       };
     }
 
@@ -31,7 +39,7 @@ export function useAttachSelectedItemsToGeneration() {
       .filter(([, count]) => count > 0)
       .map(([modelId]) => modelId);
 
-    const totalReferences = generationState.currentReferenceImages.length + selectedItems.length;
+    const totalReferences = generationState.currentReferenceImages.length + imageOnlyItems.length;
     const fit = canAttachReferenceCount(models, selectedModelIds, totalReferences);
 
     if (!fit.allowed) {
@@ -46,7 +54,7 @@ export function useAttachSelectedItemsToGeneration() {
       };
     }
 
-    const newReferences: ReferenceImage[] = selectedItems.map((item) => ({
+    const newReferences: ReferenceImage[] = imageOnlyItems.map((item) => ({
       id: crypto.randomUUID(),
       blob: item.originalBlob,
       url: URL.createObjectURL(item.originalBlob),

--- a/app/hooks/useGenerationTask.ts
+++ b/app/hooks/useGenerationTask.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { deleteImage as dbDeleteImage, getReferenceImagesByIds, saveImage } from "~/lib/db";
 import { enqueueImageEmbedding } from "~/lib/embeddingQueue";
 import { executeGeneration, type GenerationResult } from "~/lib/generation";
-import { createThumbnailBlob } from "~/lib/imageProcessing";
+import { createMediaThumbnailBlob } from "~/lib/imageProcessing";
 import { getModel } from "~/lib/models";
 import { providerRequiresApiKey } from "~/lib/providers";
 import { retryWithBackoff } from "~/lib/retry";
@@ -126,7 +126,7 @@ export function useGenerationTask() {
             return;
           }
 
-          const thumbnailBlob = await createThumbnailBlob(result.blob, 400);
+          const thumbnailBlob = await createMediaThumbnailBlob(result.blob, 400);
           if (isItemCanceled(itemId)) return;
 
           await saveImage({

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -131,6 +131,58 @@ export const BUILT_IN_MODELS: StoredModel[] = [
       resolutionKey: "size",
     },
   },
+  // --- Video models (disabled by default; enable in Settings) ---
+  {
+    id: "replicate/google/veo-3-fast",
+    name: "Veo 3 Fast",
+    provider: "replicate",
+    enabled: false,
+    icon: "/icons/google.svg",
+    capabilities: {
+      outputType: "video",
+      supportsAspectRatios: true,
+      supportedAspectRatios: ["16:9", "9:16"],
+      supportsResolution: false,
+      supportsReferenceImages: false,
+      maxReferenceImages: 0,
+    },
+  },
+  {
+    id: "replicate/minimax/video-01",
+    name: "Hailuo Video",
+    provider: "replicate",
+    enabled: false,
+    icon: "/icons/replicate.svg",
+    capabilities: {
+      outputType: "video",
+      supportsAspectRatios: false,
+      supportedAspectRatios: [],
+      supportsResolution: false,
+      supportsReferenceImages: true,
+      maxReferenceImages: 1,
+    },
+    schemaMapping: {
+      imageInputKey: "first_frame_image",
+    },
+  },
+  {
+    id: "replicate/kwaivgi/kling-v2.1-pro",
+    name: "Kling v2.1 Pro",
+    provider: "replicate",
+    enabled: false,
+    icon: "/icons/replicate.svg",
+    capabilities: {
+      outputType: "video",
+      supportsAspectRatios: true,
+      supportedAspectRatios: ["16:9", "9:16", "1:1"],
+      supportsResolution: false,
+      supportsReferenceImages: true,
+      maxReferenceImages: 1,
+    },
+    schemaMapping: {
+      imageInputKey: "start_image",
+    },
+  },
 ];
 
 export function mergeWithBuiltInModels(models?: StoredModel[]): StoredModel[] {

--- a/app/lib/imageProcessing.ts
+++ b/app/lib/imageProcessing.ts
@@ -187,19 +187,24 @@ function captureVideoFrame(
     video.muted = true;
     video.playsInline = true;
 
-    video.onloadedmetadata = () => {
-      // Seek slightly in to avoid blank first frames on some codecs.
-      video.currentTime = Math.min(0.1, video.duration / 2);
+    const resolveWithCurrentFrame = () => {
+      resolve({ element: video, url, width: video.videoWidth, height: video.videoHeight });
     };
 
-    video.onseeked = () => {
-      resolve({
-        element: video,
-        url,
-        width: video.videoWidth,
-        height: video.videoHeight,
-      });
+    video.onloadedmetadata = () => {
+      const dur = video.duration;
+      // duration may be 0, NaN, or Infinity for some formats/streams. When we
+      // can't seek to a meaningful offset, resolve immediately with frame 0 —
+      // setting currentTime=0 (already the position) won't fire onseeked.
+      if (!Number.isFinite(dur) || dur <= 0) {
+        resolveWithCurrentFrame();
+        return;
+      }
+      // Seek slightly in to avoid blank first frames on some codecs.
+      video.currentTime = Math.min(0.1, dur / 2);
     };
+
+    video.onseeked = resolveWithCurrentFrame;
 
     video.onerror = () => {
       URL.revokeObjectURL(url);

--- a/app/lib/imageProcessing.ts
+++ b/app/lib/imageProcessing.ts
@@ -112,3 +112,101 @@ function loadImageFromBlob(blob: Blob): Promise<HTMLImageElement> {
     img.src = url;
   });
 }
+
+// --- Media-aware helpers (handles both images and videos) ---
+
+export async function getMediaDimensions(blob: Blob): Promise<{ width: number; height: number }> {
+  if (blob.type.startsWith("video/")) {
+    return getVideoDimensions(blob);
+  }
+  return getImageDimensions(blob);
+}
+
+export async function createMediaThumbnailBlob(
+  originalBlob: Blob,
+  maxWidth: number = 400
+): Promise<Blob> {
+  if (originalBlob.type.startsWith("video/")) {
+    return createVideoThumbnailBlob(originalBlob, maxWidth);
+  }
+  return createThumbnailBlob(originalBlob, maxWidth);
+}
+
+function getVideoDimensions(blob: Blob): Promise<{ width: number; height: number }> {
+  return new Promise((resolve) => {
+    const video = document.createElement("video");
+    const url = URL.createObjectURL(blob);
+
+    video.onloadedmetadata = () => {
+      const width = video.videoWidth || 1920;
+      const height = video.videoHeight || 1080;
+      URL.revokeObjectURL(url);
+      resolve({ width, height });
+    };
+
+    video.onerror = () => {
+      URL.revokeObjectURL(url);
+      resolve({ width: 1920, height: 1080 });
+    };
+
+    video.src = url;
+    video.load();
+  });
+}
+
+async function createVideoThumbnailBlob(blob: Blob, maxWidth: number): Promise<Blob> {
+  try {
+    const frame = await captureVideoFrame(blob);
+    const targetWidth = Math.min(frame.width, maxWidth);
+    const scale = targetWidth / frame.width;
+    const targetHeight = Math.max(1, Math.round(frame.height * scale));
+
+    const canvas = document.createElement("canvas");
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return blob;
+
+    ctx.drawImage(frame.element, 0, 0, targetWidth, targetHeight);
+    URL.revokeObjectURL(frame.url);
+
+    const thumbnail = await canvasToBlob(canvas, "image/webp", 0.88);
+    return thumbnail ?? blob;
+  } catch {
+    return blob;
+  }
+}
+
+function captureVideoFrame(
+  blob: Blob
+): Promise<{ element: HTMLVideoElement; url: string; width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const video = document.createElement("video");
+    const url = URL.createObjectURL(blob);
+    video.muted = true;
+    video.playsInline = true;
+
+    video.onloadedmetadata = () => {
+      // Seek slightly in to avoid blank first frames on some codecs.
+      video.currentTime = Math.min(0.1, video.duration / 2);
+    };
+
+    video.onseeked = () => {
+      resolve({
+        element: video,
+        url,
+        width: video.videoWidth,
+        height: video.videoHeight,
+      });
+    };
+
+    video.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Failed to load video for thumbnail"));
+    };
+
+    video.src = url;
+    video.load();
+  });
+}

--- a/app/lib/models.ts
+++ b/app/lib/models.ts
@@ -26,6 +26,20 @@ export function getModel(models: StoredModel[], modelId: string): StoredModel | 
   return models.find((m) => m.id === modelId);
 }
 
+export function isVideoModel(model: StoredModel): boolean {
+  return model.capabilities.outputType === "video";
+}
+
+export function anySelectedModelIsVideo(
+  models: StoredModel[],
+  selectedModelIds: string[]
+): boolean {
+  return selectedModelIds.some((id) => {
+    const model = getModel(models, id);
+    return model ? isVideoModel(model) : false;
+  });
+}
+
 // Helper to check if any selected model supports aspect ratios
 export function anyModelSupportsAspectRatio(
   models: StoredModel[],
@@ -231,8 +245,10 @@ export function anyModelSupportsNumberOfImages(
 }
 
 // Strictest batch cap across selected batch-aware models. Falls back to 1
-// when no selected model advertises the capability.
+// when no selected model advertises the capability. Always 1 for video models.
 export function getMaxImagesPerRequest(models: StoredModel[], selectedModelIds: string[]): number {
+  if (anySelectedModelIsVideo(models, selectedModelIds)) return 1;
+
   let limit = Infinity;
   let sawBatchModel = false;
 

--- a/app/lib/prompts.ts
+++ b/app/lib/prompts.ts
@@ -197,5 +197,6 @@ Rules:
 - "maxImagesPerRequest": include ONLY alongside "numberOfImagesKey". Use the schema's "maximum" if present, otherwise a conservative integer like 4.
 - Only include "extraDefaults" for parameters with important non-obvious defaults our app doesn't set
 - If there are values in the schema relating to things like safety filters or content restrictions, set them to their most permissive values in "extraDefaults" (e.g. "safety_filter": "off").
+- "outputType": set to "video" if this model generates video clips / mp4 output (look for output schema type "string" with format "uri" and description mentioning "video", "mp4", or "clip", or if input parameters include "duration", "num_frames", "fps", "frame_rate"). Omit or set to "image" otherwise.
 - You should return at least an empty object if all parameters already conform to our schema.
 - Return ONLY valid the JSON mapping object, no explanation or markdown`;

--- a/app/lib/providers/replicate.ts
+++ b/app/lib/providers/replicate.ts
@@ -1,7 +1,7 @@
 import { distance } from "fastest-levenshtein";
 import Replicate from "replicate";
 import type { GenerationParams, GenerationResult } from "~/lib/generation";
-import { getImageDimensions } from "~/lib/imageProcessing";
+import { getMediaDimensions } from "~/lib/imageProcessing";
 import { inferIcon, inferName } from "~/lib/modelNames";
 import { dereferenceProperties, type OpenApiSchemaProperty } from "~/lib/openapi";
 import { SCHEMA_MAPPING_SYSTEM } from "~/lib/prompts";
@@ -70,19 +70,19 @@ async function generateImage(
     throw toRateLimitError(error, "replicate");
   }
 
-  // Normalize output to a list of image URLs. Replicate returns either a single
+  // Normalize output to a list of URLs. Replicate returns either a single
   // string/FileOutput, or an array of them for batch-capable models.
   const urls = extractReplicateUrls(output);
-  if (urls.length === 0) throw new Error("No image in Replicate response");
+  if (urls.length === 0) throw new Error("No output in Replicate response");
 
   const results = await Promise.all(
     urls.map(async (url) => {
       const response = await fetch(url);
       if (!response.ok) {
-        throw new Error(`Failed to fetch generated image: ${response.status}`);
+        throw new Error(`Failed to fetch generated output: ${response.status}`);
       }
       const blob = await response.blob();
-      const dimensions = await getImageDimensions(blob);
+      const dimensions = await getMediaDimensions(blob);
       return { blob, width: dimensions.width, height: dimensions.height, metadata: {} };
     })
   );
@@ -255,6 +255,7 @@ interface SchemaAnalysis {
   supportedAspectRatios?: string[];
   supportedQualities?: string[];
   maxImagesPerRequest?: number;
+  outputType?: "image" | "video";
 }
 
 async function fetchReplicateModelSchema(
@@ -286,13 +287,19 @@ async function fetchReplicateModelSchema(
 function inferCapabilitiesFromProperties(
   properties: Record<string, OpenApiSchemaProperty>
 ): HeuristicResult {
+  // Detect video models by the presence of temporal parameters.
+  const videoKeys = ["duration", "num_frames", "fps", "frame_rate"];
+  const isVideo = videoKeys.some((key) => properties[key]);
+
   const aspectRatioKeys = ["aspect_ratio", "aspectRatio", "output_aspect_ratio"];
   const detectedAspectRatioKey = aspectRatioKeys.find((key) => properties[key]);
   const supportsAspectRatios = !!detectedAspectRatioKey;
 
   const resolutionKeys = ["resolution", "output_resolution", "megapixels", "size"];
   const detectedResolutionKey = resolutionKeys.find((key) => properties[key]);
-  const supportsResolution = !!detectedResolutionKey;
+  // Don't expose the resolution picker for video models — their resolution
+  // semantics (480p / 720p / 1080p) don't align with the image 1K/2K/4K enum.
+  const supportsResolution = !isVideo && !!detectedResolutionKey;
 
   const imageProps = [
     "image",
@@ -302,6 +309,11 @@ function inferCapabilitiesFromProperties(
     "reference_image",
     "init_image",
     "control_image",
+    // video-model first-frame inputs
+    "start_image",
+    "first_frame_image",
+    "last_frame",
+    "image_url",
   ];
   const imageProperty = imageProps.find((prop) => properties[prop]);
   const supportsReferenceImages = !!imageProperty;
@@ -324,15 +336,18 @@ function inferCapabilitiesFromProperties(
     const prop = properties[key];
     return prop && (prop.type === "integer" || prop.type === "number");
   });
-  const supportsNumberOfImages = !!detectedNumberOfImagesKey;
-  const maxImagesPerRequest = detectedNumberOfImagesKey
-    ? typeof properties[detectedNumberOfImagesKey].maximum === "number"
-      ? properties[detectedNumberOfImagesKey].maximum
-      : 10
-    : undefined;
+  // Video models don't support batching.
+  const supportsNumberOfImages = !isVideo && !!detectedNumberOfImagesKey;
+  const maxImagesPerRequest =
+    !isVideo && detectedNumberOfImagesKey
+      ? typeof properties[detectedNumberOfImagesKey].maximum === "number"
+        ? properties[detectedNumberOfImagesKey].maximum
+        : 10
+      : undefined;
 
   return {
     capabilities: {
+      ...(isVideo ? { outputType: "video" as const } : {}),
       supportsAspectRatios,
       supportsResolution,
       supportsReferenceImages,
@@ -407,12 +422,23 @@ async function analyzeSchemaWithTextModel(
       maxImagesPerRequest = Math.floor(parsed.maxImagesPerRequest);
     }
 
+    let outputType: "image" | "video" | undefined;
+    if (parsed.outputType === "video") {
+      outputType = "video";
+    }
+
     const hasMapping = Object.keys(mapping).length > 0;
-    if (!hasMapping && !supportedAspectRatios && !supportedQualities && !maxImagesPerRequest) {
+    if (
+      !hasMapping &&
+      !supportedAspectRatios &&
+      !supportedQualities &&
+      !maxImagesPerRequest &&
+      !outputType
+    ) {
       return null;
     }
 
-    return { mapping, supportedAspectRatios, supportedQualities, maxImagesPerRequest };
+    return { mapping, supportedAspectRatios, supportedQualities, maxImagesPerRequest, outputType };
   } catch {
     return null;
   }
@@ -494,6 +520,14 @@ function mergeAnalysis(
   }
   if (typeof analysis?.maxImagesPerRequest === "number") {
     capabilities.maxImagesPerRequest = analysis.maxImagesPerRequest;
+  }
+
+  // The text model analyzer can upgrade the outputType to "video" if heuristics
+  // missed it (e.g. model has no duration key but produces video output).
+  if (analysis?.outputType === "video") {
+    capabilities.outputType = "video";
+    capabilities.supportsResolution = false;
+    capabilities.supportsNumberOfImages = false;
   }
 
   const schemaMapping = Object.keys(mapping).length > 0 ? mapping : undefined;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -7,6 +7,8 @@ export type AspectRatio = string;
 export type Resolution = "1K" | "2K" | "4K";
 
 export interface ModelCapabilities {
+  /** "video" for models that produce video clips; omit or "image" for still images. */
+  outputType?: "image" | "video";
   supportsAspectRatios: boolean;
   supportedAspectRatios?: string[]; // should use doesModelSupportAspectRatio() from models.ts to check support
   /** Model accepts any aspect ratio string within its own internal constraints (e.g. gpt-image-2). */


### PR DESCRIPTION
## Summary

- Adds `outputType?: "image" | "video"` capability flag to `ModelCapabilities` so the app has pre-call knowledge of whether a model produces stills or video clips
- Ships 3 built-in Replicate video models (all disabled by default, so the image-first UX is unchanged): **Veo 3 Fast**, **Hailuo Video** (MiniMax), **Kling v2.1 Pro**
- Branches the thumbnailing and dimension paths on MIME type — video blobs get a poster frame extracted via a hidden `<video>` element; images use the existing path
- Gallery card shows a play-icon overlay for video items; lightbox renders a `<video controls autoPlay loop muted>` instead of `<img>`, and hides the Editor / Upscale buttons
- Replicate schema introspection detects video models from temporal input keys (`duration`, `num_frames`, `fps`, `frame_rate`) and propagates `outputType: "video"` through the capability pipeline; the LLM schema-mapping step is also extended to detect video output
- Reference-image drag flow silently skips video gallery items with a clear error message
- `getMaxImagesPerRequest` returns 1 when any selected model is video (video models don't batch)
- Export/import already works — `mime/lite` resolves `video/mp4` → `.mp4` automatically

## Validation steps

1. Add a Replicate API key in Settings; enable one of the new video models
2. Generate a short prompt — card appears in masonry grid with poster frame + play-icon badge
3. Click card — lightbox plays video with controls; Editor and Upscale buttons are absent
4. Download button saves an `.mp4` file
5. Select a video card and use "Add to references" — should show "Videos cannot be used as reference images."
6. Refresh page — video reloads from IndexedDB; poster thumbnail still renders
7. Generate a normal image alongside a video — image flow is unaffected

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format` — no changes
- [x] Built-in video models are `enabled: false` by default
- [x] Editor and Upscale actions hidden for video items in lightbox
- [x] No settings store version bump required (`outputType` is optional; existing stored models default to image)
- [x] Fixed: `captureVideoFrame` Promise hang when `video.duration` is 0, NaN, or Infinity

Closes #57