### PR TITLE
feat: diff viewer in lightbox; hide on mismatched aspect ratios

### DIFF
--- a/app/components/editor/Turn.tsx
+++ b/app/components/editor/Turn.tsx
@@ -8,6 +8,7 @@ import { useDiffStore } from "~/stores/diffStore";
 import type { EditorTurn } from "~/types";
 import { SineWaveGrid } from "~/components/gallery/SineWaveGrid";
 import { useGalleryDerivedIndexes } from "~/hooks/useGalleryDerivedIndexes";
+import { aspectRatiosCompatibleForDiff } from "~/lib/models";
 
 interface TurnProps {
   turn: EditorTurn;
@@ -48,16 +49,48 @@ export function Turn({ turn, turnIndex, isFirst = false }: TurnProps) {
 
   // Parent blob (for diff viewer): either the source gallery item's full-res blob,
   // or the original source blob if this turn edits the original.
-  const { parentBlob, parentLabel } = useMemo(() => {
+  const { parentBlob, parentLabel, parentItemAspect } = useMemo(() => {
     if (turn.sourceItemId) {
       const item = getItemById(turn.sourceItemId);
       if (item && item.status === "completed") {
-        return { parentBlob: item.originalBlob, parentLabel: item.modelName };
+        const aspect =
+          item.width > 0 && item.height > 0 ? item.width / item.height : null;
+        return {
+          parentBlob: item.originalBlob,
+          parentLabel: item.modelName,
+          parentItemAspect: aspect,
+        };
       }
-      return { parentBlob: null, parentLabel: undefined };
+      return { parentBlob: null, parentLabel: undefined, parentItemAspect: null };
     }
-    return { parentBlob: turn.sourceBlob ?? null, parentLabel: "Source" };
+    return { parentBlob: turn.sourceBlob ?? null, parentLabel: "Source", parentItemAspect: null };
   }, [getItemById, turn.sourceItemId, turn.sourceBlob]);
+
+  // When the parent is an uploaded blob (no gallery item), read its natural dimensions
+  // once so we can compare aspect ratios against child outputs.
+  const [parentBlobAspect, setParentBlobAspect] = useState<number | null>(null);
+  useEffect(() => {
+    if (parentItemAspect != null || !parentBlob) {
+      setParentBlobAspect(null);
+      return;
+    }
+    let cancelled = false;
+    const url = URL.createObjectURL(parentBlob);
+    const img = new Image();
+    img.onload = () => {
+      if (cancelled) return;
+      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+        setParentBlobAspect(img.naturalWidth / img.naturalHeight);
+      }
+    };
+    img.src = url;
+    return () => {
+      cancelled = true;
+      URL.revokeObjectURL(url);
+    };
+  }, [parentBlob, parentItemAspect]);
+
+  const parentAspect = parentItemAspect ?? parentBlobAspect;
 
   // Auto-select the first completed item in the most recent turn (once only)
   const isLastTurn = turnIndex === turns.length - 1;
@@ -132,8 +165,12 @@ export function Turn({ turn, turnIndex, isFirst = false }: TurnProps) {
                   isSelected={isSelected}
                   onClick={() => selectItem(item.id)}
                   childBlob={item.originalBlob}
+                  childAspect={
+                    item.width > 0 && item.height > 0 ? item.width / item.height : null
+                  }
                   parentBlob={parentBlob}
                   parentLabel={parentLabel}
+                  parentAspect={parentAspect}
                 />
               );
             }
@@ -167,8 +204,10 @@ function EditorImageCard({
   onClick,
   itemId,
   childBlob,
+  childAspect,
   parentBlob,
   parentLabel,
+  parentAspect,
 }: {
   thumbnailUrl: string;
   modelName: string;
@@ -176,9 +215,16 @@ function EditorImageCard({
   onClick: () => void;
   itemId: string;
   childBlob: Blob;
+  childAspect: number | null;
   parentBlob: Blob | null;
   parentLabel?: string;
+  parentAspect: number | null;
 }) {
+  const canDiff =
+    parentBlob != null &&
+    parentAspect != null &&
+    childAspect != null &&
+    aspectRatiosCompatibleForDiff(parentAspect, childAspect);
   const [isLoaded, setIsLoaded] = useState(false);
   const openLightbox = useLightboxStore((s) => s.openLightbox);
   const openDiff = useDiffStore((s) => s.openDiff);
@@ -240,7 +286,7 @@ function EditorImageCard({
         </div>
 
         {/* Diff button (hover only) */}
-        {parentBlob && (
+        {canDiff && parentBlob && (
           <div
             className="opacity-0 transition-opacity duration-150 group-hover:opacity-100"
             onClick={(e) => {

--- a/app/components/lightbox/Lightbox.tsx
+++ b/app/components/lightbox/Lightbox.tsx
@@ -23,6 +23,7 @@ import { useLightboxStore } from "~/stores/lightboxStore";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { useEditorStore } from "~/stores/editorStore";
 import { GalleryImageCard } from "~/components/gallery/GalleryImageCard";
+import { RelatedThumbnail } from "./RelatedThumbnail";
 import { useLightboxNavigation } from "~/hooks/useLightboxNavigation";
 import { useGalleryDerivedIndexes } from "~/hooks/useGalleryDerivedIndexes";
 import {
@@ -456,7 +457,12 @@ export function Lightbox() {
                   </h3>
                   <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-2">
                     {promptGroup.map((item) => (
-                      <GalleryImageCard key={item.id} item={item} selectionDisabled />
+                      <RelatedThumbnail
+                        key={item.id}
+                        kind="gallery-item"
+                        current={galleryImage}
+                        item={item}
+                      />
                     ))}
                   </div>
                 </div>
@@ -474,19 +480,19 @@ export function Lightbox() {
                         ? getItemById(img.sourceGalleryItemId)
                         : null;
                       return sourceItem ? (
-                        <GalleryImageCard key={img.id} item={sourceItem} selectionDisabled />
-                      ) : (
-                        <button
+                        <RelatedThumbnail
                           key={img.id}
-                          onClick={() => openLightbox({ kind: "reference", image: img })}
-                          className="bg-surface-overlay hover:ring-c-border overflow-hidden rounded-lg transition-all hover:ring-2"
-                        >
-                          <img
-                            src={img.url}
-                            alt={img.name}
-                            className="aspect-square w-full object-cover"
-                          />
-                        </button>
+                          kind="gallery-item"
+                          current={galleryImage}
+                          item={sourceItem}
+                        />
+                      ) : (
+                        <RelatedThumbnail
+                          key={img.id}
+                          kind="external-ref"
+                          current={galleryImage}
+                          image={img}
+                        />
                       );
                     })}
                   </div>
@@ -501,7 +507,12 @@ export function Lightbox() {
                   </h3>
                   <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-2">
                     {childItems.map((item) => (
-                      <GalleryImageCard key={item.id} item={item} selectionDisabled />
+                      <RelatedThumbnail
+                        key={item.id}
+                        kind="gallery-item"
+                        current={galleryImage}
+                        item={item}
+                      />
                     ))}
                   </div>
                 </div>

--- a/app/components/lightbox/RelatedThumbnail.tsx
+++ b/app/components/lightbox/RelatedThumbnail.tsx
@@ -1,0 +1,120 @@
+import { Layers2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { GalleryImageCard } from "~/components/gallery/GalleryImageCard";
+import { useLightboxStore } from "~/stores/lightboxStore";
+import { useDiffStore } from "~/stores/diffStore";
+import { aspectRatiosCompatibleForDiff } from "~/lib/models";
+import type { CompletedGalleryItem, GalleryItem, ReferenceImage } from "~/types";
+
+type RelatedThumbnailProps =
+  | {
+      kind: "gallery-item";
+      current: CompletedGalleryItem;
+      item: GalleryItem;
+    }
+  | {
+      kind: "external-ref";
+      current: CompletedGalleryItem;
+      image: ReferenceImage;
+    };
+
+export function RelatedThumbnail(props: RelatedThumbnailProps) {
+  const { current } = props;
+  const openDiff = useDiffStore((s) => s.openDiff);
+  const openLightbox = useLightboxStore((s) => s.openLightbox);
+
+  // Determine the child's aspect ratio + blob + label.
+  const externalRefUrl = props.kind === "external-ref" ? props.image.url : null;
+  const [externalRefAspect, setExternalRefAspect] = useState<number | null>(null);
+  useEffect(() => {
+    if (!externalRefUrl) {
+      setExternalRefAspect(null);
+      return;
+    }
+    let cancelled = false;
+    const img = new Image();
+    img.onload = () => {
+      if (cancelled) return;
+      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+        setExternalRefAspect(img.naturalWidth / img.naturalHeight);
+      }
+    };
+    img.src = externalRefUrl;
+    return () => {
+      cancelled = true;
+    };
+  }, [externalRefUrl]);
+
+  const currentAspect =
+    current.width > 0 && current.height > 0 ? current.width / current.height : null;
+
+  let childBlob: Blob | null = null;
+  let childAspect: number | null = null;
+  let childLabel: string | undefined;
+  let isSelf = false;
+
+  if (props.kind === "gallery-item") {
+    if (props.item.status === "completed") {
+      childBlob = props.item.originalBlob;
+      childAspect =
+        props.item.width > 0 && props.item.height > 0
+          ? props.item.width / props.item.height
+          : null;
+      childLabel = props.item.modelName;
+    }
+    isSelf = props.item.id === current.id;
+  } else {
+    childBlob = props.image.blob;
+    childAspect = externalRefAspect;
+    childLabel = props.image.name;
+  }
+
+  const canDiff =
+    !isSelf &&
+    childBlob != null &&
+    currentAspect != null &&
+    childAspect != null &&
+    aspectRatiosCompatibleForDiff(currentAspect, childAspect);
+
+  const handleDiffClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!canDiff || !childBlob) return;
+    openDiff({
+      parentBlob: current.originalBlob,
+      childBlob,
+      parentLabel: current.modelName,
+      childLabel,
+    });
+  };
+
+  return (
+    <div className="group/related relative">
+      {props.kind === "gallery-item" ? (
+        <GalleryImageCard item={props.item} selectionDisabled />
+      ) : (
+        <button
+          type="button"
+          onClick={() => openLightbox({ kind: "reference", image: props.image })}
+          className="bg-surface-overlay hover:ring-c-border overflow-hidden rounded-lg transition-all hover:ring-2"
+        >
+          <img
+            src={props.image.url}
+            alt={props.image.name}
+            className="aspect-square w-full object-cover"
+          />
+        </button>
+      )}
+
+      {canDiff && (
+        <button
+          type="button"
+          onClick={handleDiffClick}
+          title="Compare with current image"
+          className="absolute top-2 left-2 z-10 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md bg-black/60 opacity-0 backdrop-blur-sm transition-opacity duration-150 group-hover/related:opacity-100"
+        >
+          <Layers2 className="h-4 w-4 text-white/80" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/lib/models.ts
+++ b/app/lib/models.ts
@@ -21,6 +21,19 @@ export const RESOLUTIONS_LABELS: [string, Resolution][] = [
 export const QUALITIES = ["low", "medium", "high"] as const;
 export type Quality = (typeof QUALITIES)[number];
 
+export const AR_DIFF_THRESHOLD = 0.1;
+
+/** Symmetric distance between two aspect ratios (w/h). |ln(a/b)| — invariant under inversion,
+ *  so 16:9 vs 4:3 and 9:16 vs 3:4 yield the same magnitude. */
+export function aspectRatioDistance(arA: number, arB: number): number {
+  if (!(arA > 0) || !(arB > 0)) return Infinity;
+  return Math.abs(Math.log(arA / arB));
+}
+
+export function aspectRatiosCompatibleForDiff(arA: number, arB: number): boolean {
+  return aspectRatioDistance(arA, arB) < AR_DIFF_THRESHOLD;
+}
+
 // Helper to get a model by ID from a models array
 export function getModel(models: StoredModel[], modelId: string): StoredModel | undefined {
   return models.find((m) => m.id === modelId);


### PR DESCRIPTION
## Summary

- Adds a hover diff button on related thumbnails in the lightbox (All outputs, Reference images, Children). The current lightbox image is always the "before" side; the hovered thumbnail is the "after".
- Hides the diff button (both in the editor toolbar and in the new lightbox affordance) when the two images' aspect ratios differ significantly, since the `DiffViewer` sizes its canvas to the parent and `object-contain`s both layers — letterboxed children make the slider meaningless.
- Introduces a symmetric AR distance metric in `lib/models.ts`: `|ln(arA / arB)|`. This produces the same magnitude for `16:9 vs 4:3` and `9:16 vs 3:4` (0.288 each), fixing the inconsistency in a naive `w/h` difference. Threshold is `0.10` (~10.5% ratio drift).

## Changes

- `app/lib/models.ts` — new `aspectRatioDistance`, `aspectRatiosCompatibleForDiff`, `AR_DIFF_THRESHOLD`.
- `app/components/editor/Turn.tsx` — compute parent AR (either from the source gallery item or by reading `naturalWidth/Height` from the source blob), plumb child AR into `EditorImageCard`, and gate the diff button on AR compatibility.
- `app/components/lightbox/RelatedThumbnail.tsx` *(new)* — thin wrapper around `GalleryImageCard` (or the existing external-ref `<img>` button) that adds a hover-only diff icon overlay when ARs are compatible.
- `app/components/lightbox/Lightbox.tsx` — uses `RelatedThumbnail` for the three thumbnail sections.

Self-diff is suppressed when a thumbnail in *All outputs* is the same item as the lightbox subject.

## Test plan

- [ ] `pnpm typecheck` and `pnpm build` clean.
- [ ] In the editor, open a turn whose child output has a noticeably different aspect ratio from the source — diff icon should be hidden. Same-AR pairs still show it.
- [ ] In the lightbox, hover thumbnails under each of *All outputs*, *Reference images*, *Children* — diff icon appears on hover for compatible ARs and opens the slider with the lightbox image as "before". Clicking the thumbnail body still navigates as before.
- [ ] Lightbox subject's own card in *All outputs* shows no diff icon.
- [ ] External (non-gallery) reference images still work — diff respects the dimensions read from the image element.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QipUik78B7o88BGgeEkcGt)_