### PR TITLE
feat: generation cost estimation and display

### DIFF
--- a/app/components/lightbox/Lightbox.tsx
+++ b/app/components/lightbox/Lightbox.tsx
@@ -32,6 +32,7 @@ import {
 import { IconButton } from "./IconButton";
 import { ScorecardPanel } from "./ScorecardPanel";
 import { WideIconButton } from "./WideIconButton";
+import { formatCostUsd } from "~/lib/cost";
 import { findSessionForImage, getReferenceImagesByIds, saveReferenceImage } from "~/lib/db";
 import type {
   CompletedGalleryItem,
@@ -252,6 +253,7 @@ export function Lightbox() {
     galleryImage?.generationTimeMs != null
       ? `${(galleryImage.generationTimeMs / 1000).toFixed(1)}s`
       : undefined,
+    typeof galleryImage?.costUsd === "number" ? formatCostUsd(galleryImage.costUsd) : undefined,
     galleryImage?.embedding ? "Has embedding" : undefined,
   ].filter(Boolean);
 

--- a/app/components/settings/ModelToggle.tsx
+++ b/app/components/settings/ModelToggle.tsx
@@ -7,11 +7,12 @@ import {
   RefreshCw,
   GalleryHorizontalEnd,
   Sparkles,
+  DollarSign,
 } from "lucide-react";
 import { useSettingsStore } from "~/stores/settingsStore";
 import SVG from "react-inlinesvg";
 import { useState, type ReactNode } from "react";
-import type { StoredModel } from "~/types";
+import type { PricePerImageUsd, Resolution, StoredModel } from "~/types";
 import { Tooltip } from "~/components/ui/Tooltip";
 import { Switch } from "~/components/ui/Switch";
 import { AspectRatioPreview } from "~/components/ui/AspectRatioPreview";
@@ -90,6 +91,7 @@ export default function ModelToggleItem({
   const [isRefetching, setIsRefetching] = useState(false);
   const [refetchingStatus, setRefetchingStatus] = useState("");
   const [refetchError, setRefetchError] = useState<string | null>(null);
+  const [pricingExpanded, setPricingExpanded] = useState(false);
 
   const { capabilities } = model;
   const needsRefetch =
@@ -127,13 +129,15 @@ export default function ModelToggleItem({
       : "Click to refresh schema info.";
 
   const provider = PROVIDERS[model.provider];
+  const supportsPricingUI = model.provider === "replicate" || model.provider === "google";
 
   return (
     <div
-      className={`border-c-border/50 bg-surface-overlay/50 flex items-center gap-1 rounded-lg border p-2 py-2.5 ${
+      className={`border-c-border/50 bg-surface-overlay/50 flex flex-col rounded-lg border p-2 py-2.5 ${
         !hasApiKey ? "opacity-50" : ""
       }`}
     >
+      <div className="flex items-center gap-1">
       {dragHandleProps ? (
         <button
           {...dragHandleProps}
@@ -204,6 +208,20 @@ export default function ModelToggleItem({
         </Tooltip>
       )}
 
+      {supportsPricingUI && (
+        <Tooltip content="Set per-image pricing (USD)" placement="top" delay={200}>
+          <button
+            type="button"
+            onClick={() => setPricingExpanded((v) => !v)}
+            className={`text-text-muted hover:text-accent-muted shrink-0 p-1 transition-colors ${
+              model.pricePerImageUsd ? "text-accent-muted" : ""
+            }`}
+          >
+            <DollarSign className="h-4 w-4" />
+          </button>
+        </Tooltip>
+      )}
+
       {model.isCustom && (
         <button
           onClick={() => removeCustomModel(model.id)}
@@ -219,6 +237,58 @@ export default function ModelToggleItem({
         disabled={!hasApiKey}
         aria-label={`Toggle ${model.name}`}
       />
+      </div>
+      {supportsPricingUI && pricingExpanded && <PricingEditor model={model} />}
+    </div>
+  );
+}
+
+function PricingEditor({ model }: { model: StoredModel }) {
+  const updateModelPricing = useSettingsStore((s) => s.updateModelPricing);
+  const supportsResolution = model.capabilities.supportsResolution;
+  const keys: Array<{ key: keyof PricePerImageUsd; label: string }> = supportsResolution
+    ? [
+        { key: "1K", label: "1K" },
+        { key: "2K", label: "2K" },
+        { key: "4K", label: "4K" },
+      ]
+    : [{ key: "default", label: "Per image" }];
+
+  const handleChange = (key: keyof PricePerImageUsd, raw: string) => {
+    const trimmed = raw.trim();
+    const next: PricePerImageUsd = { ...(model.pricePerImageUsd ?? {}) };
+    if (trimmed === "") {
+      delete next[key];
+    } else {
+      const num = Number(trimmed);
+      if (!Number.isFinite(num) || num < 0) return;
+      next[key] = num;
+    }
+    updateModelPricing(model.id, Object.keys(next).length > 0 ? next : undefined);
+  };
+
+  return (
+    <div className="border-c-border/40 mt-2 flex flex-wrap items-center gap-2 border-t pt-2">
+      <span className="text-text-muted text-[10px] uppercase tracking-wide">USD / image</span>
+      {keys.map(({ key, label }) => {
+        const value = model.pricePerImageUsd?.[key as Resolution];
+        return (
+          <label key={key} className="flex items-center gap-1 text-xs">
+            <span className="text-text-tertiary">{label}</span>
+            <span className="text-text-muted">$</span>
+            <input
+              type="number"
+              step="0.001"
+              min="0"
+              inputMode="decimal"
+              value={typeof value === "number" ? value : ""}
+              onChange={(e) => handleChange(key, e.target.value)}
+              placeholder="—"
+              className="border-c-border/60 bg-surface-overlay text-text-primary w-20 rounded border px-1.5 py-0.5 text-xs focus:border-purple-500 focus:outline-none"
+            />
+          </label>
+        );
+      })}
     </div>
   );
 }

--- a/app/components/sidebar/GenerateButton.tsx
+++ b/app/components/sidebar/GenerateButton.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { useGenerationStore } from "~/stores/generationStore";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { useImageGeneration } from "~/hooks/useImageGeneration";
+import { estimateCostForModel, formatCostUsd } from "~/lib/cost";
 import { buildGenerationSignature } from "~/lib/generationSignature";
 import { getModel, getStrictReferenceImageLimit } from "~/lib/models";
 import { hasProviderAccess } from "~/lib/providers";
@@ -33,6 +34,35 @@ export function GenerateButton() {
 
   const activeModels = Object.entries(modelSelections).filter(([, count]) => count > 0);
   const totalImages = activeModels.reduce((sum, [, count]) => sum + count, 0);
+
+  let costEstimateUsd = 0;
+  const missingPriceModels: string[] = [];
+  for (const [modelId, count] of activeModels) {
+    const model = getModel(models, modelId);
+    if (!model) continue;
+    const maxBatch = model.capabilities.maxImagesPerRequest ?? 1;
+    const perCallImages = model.capabilities.supportsNumberOfImages
+      ? Math.max(1, Math.min(numberOfImages, maxBatch))
+      : 1;
+    const estimate = estimateCostForModel(model, {
+      aspectRatio,
+      resolution,
+      quality,
+      numberOfImages: count * perCallImages,
+    });
+    if (estimate) {
+      costEstimateUsd += estimate.totalUsd;
+    } else {
+      missingPriceModels.push(model.name);
+    }
+  }
+  const hasAnyEstimate = costEstimateUsd > 0;
+  const hasUnknownPricing = missingPriceModels.length > 0;
+  const costTooltip = hasUnknownPricing
+    ? `No pricing set for: ${missingPriceModels.join(", ")}. ${
+        hasAnyEstimate ? "Total is a lower bound." : "Add prices in Settings."
+      }`
+    : "Estimated using published per-image pricing. Actual cost may vary slightly.";
 
   const missingKeys = activeModels.some(([modelId]) => {
     const model = getModel(models, modelId);
@@ -179,6 +209,18 @@ export function GenerateButton() {
             willChange
           />
           {" pending"}
+          {(hasAnyEstimate || hasUnknownPricing) && totalImages > 0 && (
+            <>
+              {" • "}
+              <Tooltip content={costTooltip} placement="top" maxWidth="max-w-72">
+                <span className="cursor-help">
+                  {hasAnyEstimate
+                    ? `${hasUnknownPricing ? "~" : ""}${formatCostUsd(costEstimateUsd)}`
+                    : "~$?"}
+                </span>
+              </Tooltip>
+            </>
+          )}
           {" • "}
           <button
             onClick={handleClear}

--- a/app/hooks/useGenerationTask.ts
+++ b/app/hooks/useGenerationTask.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { estimateCostForModel } from "~/lib/cost";
 import { deleteImage as dbDeleteImage, getReferenceImagesByIds, saveImage } from "~/lib/db";
 import { enqueueImageEmbedding } from "~/lib/embeddingQueue";
 import { executeGeneration, type GenerationResult } from "~/lib/generation";
@@ -131,6 +132,19 @@ export function useGenerationTask() {
           const thumbnailBlob = await createThumbnailBlob(result.blob, 400);
           if (isItemCanceled(itemId)) return;
 
+          const model = getModel(models, task.modelId);
+          const estimate = model
+            ? estimateCostForModel(model, {
+                aspectRatio: task.aspectRatio,
+                resolution: task.resolution,
+                quality: task.quality,
+                numberOfImages: 1,
+                width: result.width,
+                height: result.height,
+              })
+            : null;
+          const costUsd = estimate?.perImageUsd;
+
           await saveImage({
             id: itemId,
             originalBlob: result.blob,
@@ -153,6 +167,7 @@ export function useGenerationTask() {
             parentGalleryItemIds:
               parentGalleryItemIds.length > 0 ? parentGalleryItemIds : undefined,
             metadata: result.metadata,
+            ...(costUsd !== undefined ? { costUsd } : {}),
           });
           if (isItemCanceled(itemId)) {
             await dbDeleteImage(itemId);
@@ -175,6 +190,7 @@ export function useGenerationTask() {
             metadata: result.metadata,
             parentGalleryItemIds:
               parentGalleryItemIds.length > 0 ? parentGalleryItemIds : undefined,
+            ...(costUsd !== undefined ? { costUsd } : {}),
           });
 
           if (isItemCanceled(itemId)) return;
@@ -184,7 +200,7 @@ export function useGenerationTask() {
 
       return results;
     },
-    [isItemCanceled, updateItem]
+    [isItemCanceled, models, updateItem]
   );
 
   const runTask = useCallback(

--- a/app/lib/builtInModels.ts
+++ b/app/lib/builtInModels.ts
@@ -152,6 +152,8 @@ export function mergeWithBuiltInModels(models?: StoredModel[]): StoredModel[] {
       schemaFetched: existing.schemaFetched,
       ...builtInModel,
       enabled: existing.enabled,
+      // User-supplied pricing always wins over built-in defaults.
+      ...(existing.pricePerImageUsd ? { pricePerImageUsd: existing.pricePerImageUsd } : {}),
     };
   });
 

--- a/app/lib/cost.ts
+++ b/app/lib/cost.ts
@@ -1,0 +1,33 @@
+import type { Resolution, StoredModel } from "~/types";
+import { getProvider } from "~/lib/providers";
+import type { CostEstimate, CostEstimateArgs } from "~/lib/providers/types";
+
+/** Resolves a per-image price from the user-configurable `pricePerImageUsd` map
+ *  on a stored model, falling back to `default` if the requested resolution is unset. */
+export function resolveStoredPrice(
+  model: StoredModel,
+  resolution: Resolution | null
+): number | null {
+  const prices = model.pricePerImageUsd;
+  if (!prices) return null;
+  const candidate = (resolution && prices[resolution]) ?? prices.default;
+  if (typeof candidate !== "number" || !Number.isFinite(candidate) || candidate < 0) return null;
+  return candidate;
+}
+
+export function formatCostUsd(usd: number): string {
+  if (!Number.isFinite(usd) || usd < 0) return "—";
+  if (usd === 0) return "$0";
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+export function estimateCostForModel(
+  model: StoredModel,
+  args: Omit<CostEstimateArgs, "model">
+): CostEstimate | null {
+  const provider = getProvider(model.provider);
+  if (!provider.estimateCost) return null;
+  return provider.estimateCost({ ...args, model });
+}

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -8,7 +8,7 @@ import type {
 import { createThumbnailBlob } from "./imageProcessing";
 
 const DB_NAME = "studio-image-gallery";
-const DB_VERSION = 4;
+const DB_VERSION = 5;
 
 const STORES = {
   images: "images",
@@ -69,6 +69,7 @@ export async function initDB(): Promise<IDBDatabase> {
       // v4: no schema change required; `embedding` and `embeddingModelId` are
       // optional fields on existing records. Bumping the version allows future
       // additions to hook the upgrade path.
+      // v5: adds optional `costUsd` field — populated lazily via backfill.
     };
   });
 }
@@ -270,6 +271,62 @@ export async function updateImageEmbedding(
       record.embeddingModelId = embeddingModelId;
       store.put(record);
     };
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+  });
+}
+
+export async function updateImageCost(id: string, costUsd: number | undefined): Promise<void> {
+  const db = await initDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORES.images, "readwrite");
+    const store = transaction.objectStore(STORES.images);
+    const getReq = store.get(id);
+
+    getReq.onerror = () => reject(getReq.error);
+    getReq.onsuccess = () => {
+      const record = getReq.result as StoredImageRecord | undefined;
+      if (!record) {
+        resolve();
+        return;
+      }
+      if (typeof costUsd === "number" && Number.isFinite(costUsd)) {
+        record.costUsd = costUsd;
+      } else {
+        delete record.costUsd;
+      }
+      store.put(record);
+    };
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+  });
+}
+
+/** Batches `updateImageCost` calls across many records in a single transaction. */
+export async function updateImageCostsBatch(
+  updates: Array<{ id: string; costUsd: number }>
+): Promise<void> {
+  if (updates.length === 0) return;
+  const db = await initDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORES.images, "readwrite");
+    const store = transaction.objectStore(STORES.images);
+
+    for (const { id, costUsd } of updates) {
+      const getReq = store.get(id);
+      getReq.onsuccess = () => {
+        const record = getReq.result as StoredImageRecord | undefined;
+        if (!record) return;
+        record.costUsd = costUsd;
+        store.put(record);
+      };
+    }
 
     transaction.oncomplete = () => resolve();
     transaction.onerror = () => reject(transaction.error);

--- a/app/lib/providers/google.ts
+++ b/app/lib/providers/google.ts
@@ -5,7 +5,15 @@ import { getImageDimensions } from "~/lib/imageProcessing";
 import { inferName } from "~/lib/modelNames";
 import { toRateLimitError } from "~/lib/retry";
 import { blobToBase64 } from "~/lib/util";
-import type { Provider, ResolvedImageModel, SearchResult, TextGenerationArgs } from "./types";
+import { resolveStoredPrice } from "~/lib/cost";
+import type {
+  CostEstimate,
+  CostEstimateArgs,
+  Provider,
+  ResolvedImageModel,
+  SearchResult,
+  TextGenerationArgs,
+} from "./types";
 import { normalizeModelId } from ".";
 
 async function generateImage(
@@ -266,6 +274,14 @@ async function searchTextModels(query: string, apiKey: string): Promise<SearchRe
   return rankAndLimit(textModels, query);
 }
 
+function estimateCost(args: CostEstimateArgs): CostEstimate | null {
+  const { model, resolution, numberOfImages } = args;
+  const perImageUsd = resolveStoredPrice(model, resolution);
+  if (perImageUsd === null) return null;
+  const n = Math.max(1, numberOfImages);
+  return { perImageUsd, totalUsd: perImageUsd * n };
+}
+
 export const googleProvider: Provider = {
   id: "google",
   label: "Google",
@@ -286,4 +302,5 @@ export const googleProvider: Provider = {
   searchImageModels,
   searchTextModels,
   resolveImageModel,
+  estimateCost,
 };

--- a/app/lib/providers/openai.ts
+++ b/app/lib/providers/openai.ts
@@ -5,7 +5,14 @@ import { getImageDimensions } from "~/lib/imageProcessing";
 import { toRateLimitError } from "~/lib/retry";
 import { blobToBase64 } from "~/lib/util";
 import type { AspectRatio, Resolution } from "~/types";
-import type { Provider, ResolvedImageModel, SearchResult, TextGenerationArgs } from "./types";
+import type {
+  CostEstimate,
+  CostEstimateArgs,
+  Provider,
+  ResolvedImageModel,
+  SearchResult,
+  TextGenerationArgs,
+} from "./types";
 import { inferName } from "../modelNames";
 import { normalizeModelId } from ".";
 
@@ -106,6 +113,108 @@ function resolveSize(
     return resolveGptImage2Size(aspectRatio, resolution) ?? "auto";
   }
   return ASPECT_RATIO_TO_SIZE[aspectRatio] ?? "auto";
+}
+
+// Published per-image USD prices from OpenAI's image-generation pricing page,
+// keyed by normalized model id, quality, and one of three "popular" size buckets.
+// For arbitrary gpt-image-2 sizes we pick the closest bucket by aspect ratio
+// and scale by the actual pixel-count ratio (output cost is token-proportional ≈
+// pixel-proportional).
+type SizeBucket = "square" | "portrait" | "landscape";
+
+const POPULAR_PIXELS: Record<SizeBucket, number> = {
+  square: 1024 * 1024,
+  portrait: 1024 * 1536,
+  landscape: 1536 * 1024,
+};
+
+const OPENAI_IMAGE_PRICING: Record<
+  string,
+  Record<"low" | "medium" | "high", Record<SizeBucket, number>>
+> = {
+  "gpt-image-2": {
+    low: { square: 0.006, portrait: 0.005, landscape: 0.005 },
+    medium: { square: 0.053, portrait: 0.041, landscape: 0.041 },
+    high: { square: 0.211, portrait: 0.165, landscape: 0.165 },
+  },
+  "gpt-image-1.5": {
+    low: { square: 0.009, portrait: 0.013, landscape: 0.013 },
+    medium: { square: 0.034, portrait: 0.05, landscape: 0.05 },
+    high: { square: 0.133, portrait: 0.2, landscape: 0.2 },
+  },
+  "gpt-image-1": {
+    low: { square: 0.011, portrait: 0.016, landscape: 0.016 },
+    medium: { square: 0.042, portrait: 0.063, landscape: 0.063 },
+    high: { square: 0.167, portrait: 0.25, landscape: 0.25 },
+  },
+  "gpt-image-1-mini": {
+    low: { square: 0.005, portrait: 0.006, landscape: 0.006 },
+    medium: { square: 0.011, portrait: 0.015, landscape: 0.015 },
+    high: { square: 0.036, portrait: 0.052, landscape: 0.052 },
+  },
+};
+
+function pickPricingKey(modelId: string): keyof typeof OPENAI_IMAGE_PRICING | null {
+  const id = normalizeModelId(modelId, "openai").toLowerCase();
+  if (id.includes("gpt-image-2")) return "gpt-image-2";
+  if (id.includes("gpt-image-1.5")) return "gpt-image-1.5";
+  if (id.includes("gpt-image-1-mini")) return "gpt-image-1-mini";
+  if (id.includes("gpt-image-1")) return "gpt-image-1";
+  return null;
+}
+
+function pickSizeBucket(aspectRatio: AspectRatio | null): SizeBucket {
+  if (!aspectRatio) return "square";
+  const [wStr, hStr] = aspectRatio.split(":");
+  const w = Number(wStr);
+  const h = Number(hStr);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return "square";
+  if (Math.abs(w - h) / Math.max(w, h) < 0.05) return "square";
+  return w > h ? "landscape" : "portrait";
+}
+
+function pickSizeBucketFromDims(width: number, height: number): SizeBucket {
+  if (Math.abs(width - height) / Math.max(width, height) < 0.05) return "square";
+  return width > height ? "landscape" : "portrait";
+}
+
+function estimatePixelsForGptImage2(
+  aspectRatio: AspectRatio | null,
+  resolution: Resolution | null
+): number {
+  if (!aspectRatio) return POPULAR_PIXELS.square;
+  const sizeStr = resolveGptImage2Size(aspectRatio, resolution);
+  if (!sizeStr) return GPT_IMAGE_2_RESOLUTION_PIXELS[resolution ?? "1K"];
+  const [w, h] = sizeStr.split("x").map(Number);
+  return w * h;
+}
+
+function estimateCost(args: CostEstimateArgs): CostEstimate | null {
+  const { model, aspectRatio, resolution, quality, numberOfImages, width, height } = args;
+  const key = pickPricingKey(model.id);
+  if (!key) return null;
+
+  const q: "low" | "medium" | "high" =
+    quality === "low" || quality === "medium" || quality === "high" ? quality : "medium";
+
+  const bucket =
+    width && height ? pickSizeBucketFromDims(width, height) : pickSizeBucket(aspectRatio);
+  const basePrice = OPENAI_IMAGE_PRICING[key][q][bucket];
+
+  let perImageUsd = basePrice;
+  if (key === "gpt-image-2") {
+    const actualPixels = width && height ? width * height : estimatePixelsForGptImage2(
+      aspectRatio,
+      resolution
+    );
+    const referencePixels = POPULAR_PIXELS[bucket];
+    if (referencePixels > 0 && actualPixels > 0) {
+      perImageUsd = basePrice * (actualPixels / referencePixels);
+    }
+  }
+
+  const n = Math.max(1, numberOfImages);
+  return { perImageUsd, totalUsd: perImageUsd * n };
 }
 
 function decodeBase64ToBlob(base64: string, mimeType: string): Blob {
@@ -482,4 +591,5 @@ export const openaiProvider: Provider = {
   searchImageModels,
   searchTextModels,
   resolveImageModel,
+  estimateCost,
 };

--- a/app/lib/providers/replicate.ts
+++ b/app/lib/providers/replicate.ts
@@ -5,12 +5,20 @@ import { getImageDimensions } from "~/lib/imageProcessing";
 import { inferIcon, inferName } from "~/lib/modelNames";
 import { dereferenceProperties, type OpenApiSchemaProperty } from "~/lib/openapi";
 import { SCHEMA_MAPPING_SYSTEM } from "~/lib/prompts";
+import { resolveStoredPrice } from "~/lib/cost";
 import { toRateLimitError } from "~/lib/retry";
 import { callTextModel } from "~/lib/textModel";
 import { useSettingsStore } from "~/stores/settingsStore";
 import { blobToBase64 } from "~/lib/util";
 import type { ModelCapabilities, SchemaMapping, StoredUpscaler } from "~/types";
-import type { Provider, ResolvedImageModel, SearchResult, TextGenerationArgs } from "./types";
+import type {
+  CostEstimate,
+  CostEstimateArgs,
+  Provider,
+  ResolvedImageModel,
+  SearchResult,
+  TextGenerationArgs,
+} from "./types";
 import { normalizeModelId } from ".";
 
 function replicateBaseUrl(): string {
@@ -516,6 +524,14 @@ async function resolveImageModel(
   return { name: inferName(modelId), capabilities, schemaMapping, icon: inferIcon(modelId) };
 }
 
+function estimateCost(args: CostEstimateArgs): CostEstimate | null {
+  const { model, resolution, numberOfImages } = args;
+  const perImageUsd = resolveStoredPrice(model, resolution);
+  if (perImageUsd === null) return null;
+  const n = Math.max(1, numberOfImages);
+  return { perImageUsd, totalUsd: perImageUsd * n };
+}
+
 export const replicateProvider: Provider = {
   id: "replicate",
   label: "Replicate",
@@ -537,4 +553,5 @@ export const replicateProvider: Provider = {
   searchImageModels: searchModels,
   searchUpscalers: searchModels,
   resolveImageModel,
+  estimateCost,
 };

--- a/app/lib/providers/types.ts
+++ b/app/lib/providers/types.ts
@@ -1,11 +1,32 @@
 import type { GenerationParams, GenerationResult } from "~/lib/generation";
 import type {
   ApiKeyProvider,
+  AspectRatio,
   ModelCapabilities,
   Provider as ProviderId,
+  Resolution,
   SchemaMapping,
+  StoredModel,
   StoredUpscaler,
 } from "~/types";
+
+export interface CostEstimateArgs {
+  model: StoredModel;
+  aspectRatio: AspectRatio | null;
+  resolution: Resolution | null;
+  quality: string | null;
+  numberOfImages: number;
+  /** Known output dimensions when available (e.g., backfilling a completed image). */
+  width?: number;
+  height?: number;
+}
+
+export interface CostEstimate {
+  /** Total cost in USD for all `numberOfImages` images. */
+  totalUsd: number;
+  /** Per-image cost in USD. */
+  perImageUsd: number;
+}
 
 export interface ProviderCapabilities {
   image: boolean;
@@ -61,6 +82,9 @@ export interface Provider {
     apiKey: string,
     onProgress?: (status: string) => void
   ): Promise<ResolvedImageModel>;
+
+  /** Returns USD cost estimate for the request, or null when pricing is unknown. */
+  estimateCost?(args: CostEstimateArgs): CostEstimate | null;
 }
 
 export type TextCapableProvider = Provider & {

--- a/app/stores/galleryStore.ts
+++ b/app/stores/galleryStore.ts
@@ -15,14 +15,57 @@ import {
   deleteImage as dbDeleteImage,
   deleteReferenceImage,
   toDisplayImage,
+  updateImageCostsBatch,
   updateImageFavorite,
   updateImageCharacters as dbUpdateImageCharacters,
   updateImageScorecard,
 } from "~/lib/db";
+import { estimateCostForModel } from "~/lib/cost";
+import { getModel } from "~/lib/models";
 import { useLightboxStore } from "./lightboxStore";
 import { useEmbeddingStatusStore } from "./embeddingStatusStore";
 import { enqueueMissingEmbeddings, refreshEmbeddingCounts } from "~/lib/embeddingQueue";
 import { useSettingsStore } from "./settingsStore";
+
+// Computes USD cost for any completed items lacking it, using stored fields.
+// Persists the result to IndexedDB and updates the in-memory items in one set().
+async function backfillCostsForItems(items: GalleryItem[]) {
+  const models = useSettingsStore.getState().models;
+  const updates: Array<{ id: string; costUsd: number }> = [];
+
+  for (const item of items) {
+    if (item.status !== "completed") continue;
+    if (typeof item.costUsd === "number") continue;
+    const model = getModel(models, item.modelId);
+    if (!model) continue;
+    const estimate = estimateCostForModel(model, {
+      aspectRatio: item.aspectRatio,
+      resolution: item.resolution,
+      quality: item.quality ?? null,
+      numberOfImages: 1,
+      width: item.width,
+      height: item.height,
+    });
+    if (!estimate) continue;
+    updates.push({ id: item.id, costUsd: estimate.perImageUsd });
+  }
+
+  if (updates.length === 0) return;
+
+  try {
+    await updateImageCostsBatch(updates);
+  } catch (error) {
+    console.error("Failed to backfill image costs:", error);
+    return;
+  }
+
+  const byId = new Map(updates.map((u) => [u.id, u.costUsd]));
+  useGalleryStore.setState((state) => ({
+    items: state.items.map((item) =>
+      byId.has(item.id) ? { ...item, costUsd: byId.get(item.id) } : item
+    ),
+  }));
+}
 
 function maybeKickEmbeddingQueue() {
   if (typeof window === "undefined") return;
@@ -132,6 +175,7 @@ export const useGalleryStore = create<GalleryState>()((set, get) => ({
         totalCount: total,
       });
       maybeKickEmbeddingQueue();
+      void backfillCostsForItems(items);
     } catch (error) {
       console.error("Failed to load images:", error);
     } finally {
@@ -157,6 +201,7 @@ export const useGalleryStore = create<GalleryState>()((set, get) => ({
         hasMore: records.length >= PAGE_SIZE,
       }));
       maybeKickEmbeddingQueue();
+      void backfillCostsForItems(fresh);
     } catch (error) {
       console.error("Failed to load more images:", error);
     } finally {

--- a/app/stores/settingsStore.ts
+++ b/app/stores/settingsStore.ts
@@ -15,6 +15,7 @@ import type {
   ApiKeyProvider,
   ApiKeys,
   ModelCapabilities,
+  PricePerImageUsd,
   SchemaMapping,
   StoredCharacter,
   StoredModel,
@@ -59,6 +60,7 @@ interface SettingsState {
     schemaFetched?: boolean
   ) => void;
   updateModelSchemaMapping: (id: string, schemaMapping: SchemaMapping) => void;
+  updateModelPricing: (id: string, pricePerImageUsd: PricePerImageUsd | undefined) => void;
 
   // Upscaler actions
   setUpscalerEnabled: (id: string, enabled: boolean) => void;
@@ -196,6 +198,20 @@ export const useSettingsStore = create<SettingsState>()(
       updateModelSchemaMapping: (id, schemaMapping) =>
         set((state) => ({
           models: state.models.map((m) => (m.id === id ? { ...m, schemaMapping } : m)),
+        })),
+
+      updateModelPricing: (id, pricePerImageUsd) =>
+        set((state) => ({
+          models: state.models.map((m) => {
+            if (m.id !== id) return m;
+            const next: StoredModel = { ...m };
+            if (pricePerImageUsd && Object.keys(pricePerImageUsd).length > 0) {
+              next.pricePerImageUsd = pricePerImageUsd;
+            } else {
+              delete next.pricePerImageUsd;
+            }
+            return next;
+          }),
         })),
 
       selectTextModel: (id) =>
@@ -411,7 +427,7 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: "studio-settings",
-      version: 21,
+      version: 22,
       partialize: (state) => ({
         apiKeys: state.apiKeys,
         models: state.models,

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -34,6 +34,16 @@ export interface ModelDefinition {
   icon?: string;
 }
 
+// Per-resolution prices in USD/image. `default` is used when no resolution is set
+// or when the model doesn't expose resolution. Used by Replicate (no public
+// pricing introspection) and as user-overridable values for built-ins.
+export interface PricePerImageUsd {
+  default?: number;
+  "1K"?: number;
+  "2K"?: number;
+  "4K"?: number;
+}
+
 // Model stored in settings (user-configurable)
 export interface StoredModel {
   id: string;
@@ -45,6 +55,7 @@ export interface StoredModel {
   schemaMapping?: SchemaMapping; // parameter translation for non-standard Replicate models
   capabilities: ModelCapabilities;
   icon?: string; // Path to custom icon SVG (e.g., "/icons/google.svg")
+  pricePerImageUsd?: PricePerImageUsd;
 }
 
 // Generation types
@@ -103,6 +114,8 @@ export interface BaseGalleryItem {
   characterIds?: string[];
   isFavorite?: boolean;
   loadingPreview?: LoadingPreview;
+  /** Estimated or actual generation cost in USD. Populated on completion or via backfill. */
+  costUsd?: number;
 }
 
 export interface PendingGalleryItemFields {
@@ -173,6 +186,7 @@ export interface StoredImageRecord {
   embedding?: number[];
   embeddingModelId?: string;
   scorecard?: ImageScorecard;
+  costUsd?: number;
 }
 
 export type ScorecardCriterion =


### PR DESCRIPTION
## Summary

Closes #58. Adds per-image cost estimation across providers, with display in the sidebar before generation and on completed gallery items in the lightbox.

- New optional `estimateCost(args)` method on the provider interface. Returns USD totals or `null` when pricing isn't known.
- **OpenAI**: published per-image pricing table for `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, and `gpt-image-2`. For gpt-image-2's arbitrary sizes, scales by pixel ratio off the closest popular bucket (square / portrait / landscape).
- **Google + Replicate**: read from a user-supplied per-resolution `pricePerImageUsd` map on `StoredModel`. The settings model row gains a USD/image editor (1K/2K/4K when the model exposes resolution, otherwise a single "Per image" field). Hidden behind a $ button on each row.
- Stores `costUsd` on each completed gallery item; bumps IndexedDB to v5 (no schema migration needed — optional field).
- Sidebar shows the total estimate next to the pending count. A `~` prefix indicates a lower bound when one or more selected models lack pricing; tooltip lists the offenders.
- Lightbox info panel renders the per-image cost as another chip in the metadata row.
- Background backfill on gallery load computes `costUsd` for legacy records that have enough stored info (model, dims, quality). Batched into a single IDB transaction.

Settings persist version: 21 → 22 (no migration logic — `pricePerImageUsd` is optional and `mergeWithBuiltInModels` already preserves user-supplied values).

## Test plan

- [ ] **Pre-generation estimate**: select GPT-Image-2 + quality=high + 4 images at 1:1. Sidebar should show ~$0.84. Toggle quality to low → drops to ~$0.024.
- [ ] **Mixed providers**: select Gemini + GPT-Image-2 simultaneously. Without Gemini prices set, total is `~$X.XX` with a tooltip listing Gemini as missing.
- [ ] **Replicate per-resolution pricing**: in Settings, open the $ editor on Nano Banana Pro, set `1K=$0.05` and `2K=$0.10`. Switch resolution in the sidebar; the estimate updates. Clear the 4K price → at 4K the sidebar reverts to `~$X` with a tooltip.
- [ ] **Lightbox**: open any completed image; cost appears next to dimensions.
- [ ] **Backfill**: hard-reload the gallery. DevTools → IndexedDB shows existing items gaining a `costUsd` field; reopen the lightbox and confirm it renders.
- [ ] **DB upgrade**: clear IDB and regenerate to confirm v5 from scratch; also load an existing v4 DB and confirm no errors.
- [ ] **Typecheck/build**: `pnpm typecheck && pnpm build` clean.

https://claude.ai/code/session_0197Ey1Mp75CojSbJbZdibCo

---
_Generated by [Claude Code](https://claude.ai/code/session_0197Ey1Mp75CojSbJbZdibCo)_