### PR TITLE
fix: portal reference markup overlay so it goes fullscreen again

### DIFF
--- a/app/components/reference/ReferenceImageMarkupOverlay.tsx
+++ b/app/components/reference/ReferenceImageMarkupOverlay.tsx
@@ -1,5 +1,6 @@
 import { X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { ASPECT_RATIOS, parseAspectRatio } from "~/lib/models";
 import type { ReferenceImage } from "~/types";
 import { CropBoxOverlay } from "./CropBoxOverlay";
@@ -448,7 +449,9 @@ export function ReferenceImageMarkupOverlay({
     onClose();
   };
 
-  return (
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
     <div className="fixed inset-0 z-[60] flex flex-col bg-black/90 backdrop-blur-sm">
       <div className="border-border-subtle flex h-14 shrink-0 items-center justify-between border-b px-4">
         <div className="flex min-w-0 items-center gap-2">
@@ -528,7 +531,8 @@ export function ReferenceImageMarkupOverlay({
           onUse={() => void handleUse()}
         />
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 


### PR DESCRIPTION
## Summary

- The floating sidebar uses `backdrop-blur-xl`. Per CSS spec, any element with a non-`none` `backdrop-filter` becomes a containing block for `position: fixed` descendants.
- That trapped `ReferenceImageMarkupOverlay` (rendered as a child of `PromptInput` inside the sidebar) inside the 320px sidebar instead of going fullscreen.
- Render the overlay through `createPortal(..., document.body)` so its `fixed inset-0` resolves against the viewport again.

## Test plan

- [ ] Open the gallery sidebar, attach a reference image, click the edit button on it → overlay covers the full viewport
- [ ] Overlay still works in the image editor's `EditorInputBar` (unaffected — it wasn't inside the sidebar, but verify no regression)
- [ ] Escape still closes the overlay; body scroll lock still applied

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtiLCwxF7gcbT8GZ7dUpTw)_