### PR TITLE
feat: close lightbox when clicking image background

### DIFF
--- a/app/components/lightbox/Lightbox.tsx
+++ b/app/components/lightbox/Lightbox.tsx
@@ -239,6 +239,35 @@ export function Lightbox() {
     void toggleItemFavorite(galleryImage.id);
   }, [galleryImage, toggleItemFavorite]);
 
+  // Clicking the empty letterbox area around the image closes the lightbox, but
+  // clicking the visible image pixels does not. Because the <img> uses
+  // object-contain, its element box can be larger than the rendered image, so we
+  // only swallow the click when it lands inside the actual rendered rectangle.
+  const handleImageClick = useCallback((e: React.MouseEvent<HTMLImageElement>) => {
+    const img = e.currentTarget;
+    const { naturalWidth, naturalHeight } = img;
+    const rect = img.getBoundingClientRect();
+    if (!naturalWidth || !naturalHeight || !rect.width || !rect.height) return;
+
+    const scale = Math.min(rect.width / naturalWidth, rect.height / naturalHeight);
+    const renderedWidth = naturalWidth * scale;
+    const renderedHeight = naturalHeight * scale;
+    const offsetX = (rect.width - renderedWidth) / 2;
+    const offsetY = (rect.height - renderedHeight) / 2;
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const onImage =
+      x >= offsetX &&
+      x <= offsetX + renderedWidth &&
+      y >= offsetY &&
+      y <= offsetY + renderedHeight;
+
+    // Only block the close when the click is on the actual image pixels;
+    // letterbox clicks fall through to the section handler below.
+    if (onImage) e.stopPropagation();
+  }, []);
+
   if (!galleryImage && !referenceImage) return null;
 
   const imageSrc = galleryImage?.originalUrl ?? referenceImage?.url ?? "";
@@ -361,11 +390,15 @@ export function Lightbox() {
               : "lg:grid-cols-1"
           }`}
         >
-          <section className="flex min-h-[52dvh] items-center justify-center overflow-hidden lg:min-h-0">
+          <section
+            className="flex min-h-[52dvh] cursor-default items-center justify-center overflow-hidden lg:min-h-0"
+            onClick={closeLightbox}
+          >
             <img
               src={imageSrc}
               alt={imageAlt}
-              className="block max-h-[calc(70dvh)] max-w-full object-contain lg:h-full lg:max-h-full lg:w-full"
+              onClick={handleImageClick}
+              className="block max-h-[calc(70dvh)] max-w-full cursor-auto object-contain lg:h-full lg:max-h-full lg:w-full"
             />
           </section>
 


### PR DESCRIPTION
## Summary

Clicking the background area of the lightbox now closes it, while clicking the actual image does not.

The nuance here (per #77): the `<img>` uses `object-contain`, so on the `lg` layout the image element's box is larger than the rendered image — there's letterbox padding inside the element. Those empty letterbox regions should be clickable to close, even though they're technically inside the `<img>` element's bounding box.

## Changes

- The centering `<section>` around the image now closes the lightbox on click (this is the backdrop).
- A click handler on the `<img>` computes the actual rendered image rectangle (using `naturalWidth`/`naturalHeight` and the element's bounds with `object-contain` math). It only calls `stopPropagation()` when the click lands on the visible image pixels — letterbox clicks fall through to the section handler and close the lightbox.

## Behavior

- Click on visible image pixels → stays open
- Click on letterbox area inside the image box → closes
- Click on empty space around the image → closes

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1knWoLCeKre8K9PK8sTuZ)_